### PR TITLE
feat(enrich): Jina enrichment + Twitter field preservation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,13 @@ The fetch window is **30h** (not 24h): daily runs don't fire at exactly the same
 For each source entry in the snapshot:
 - If `status === "ok"` or `status === "degraded_stale"`: iterate `articles[]` (already pre-filtered to the 30h window). Skip any whose SHA-256 URL hash is already in `data/history.json`. Collect the rest for analysis.
 - If `status === "error"`: skip for content, note the error for Health Monitoring.
+- `articles`: list of `{ title, url, published_at, description, full_text?, linked_content?, expanded_urls?, quoted_tweet?, reply_to? }` — already pre-filtered to `window_hours` of recency (overlap with yesterday is handled by URL-hash dedup in history.json).
+  - `full_text` (blog sources): full article body (markdown from Jina Reader or upstream HTML). Null when enrichment failed. Absent for Twitter sources.
+  - `linked_content` (primary Twitter sources only): Jina-fetched body of the primary-blog URL the tweet links to, when one exists. Null when no matching URL or fetch failed.
+  - `expanded_urls` (Twitter): `[{ t_co, expanded_url, display_url }]` from `entities.urls`.
+  - `quoted_tweet` (Twitter): `{ author, text, url }` when the tweet is a quote-tweet, else null.
+  - `reply_to` (Twitter): `{ screen_name, status_id }` when the tweet is a reply, else null.
+  - **Summary-source priority when analyzing:** `linked_content` > `full_text` > `quoted_tweet.text + description` > `description`.
 
 For newsletter-style sources (Berkeley RDI, The Batch) whose articles bundle multiple topics, split into separate entries — append `#topic-N` to the URL, each entry independently categorized.
 

--- a/docs/superpowers/plans/2026-04-22-enrichment-plan.md
+++ b/docs/superpowers/plans/2026-04-22-enrichment-plan.md
@@ -1,0 +1,1019 @@
+# CatchUp Enrichment Implementation Plan (PR 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich fetch-cache articles so Claude's daily analysis works from real content, not RSS blurbs — via Jina Reader for blog sources + socialdata field preservation and optional Jina-follow for primary Twitter sources.
+
+**Architecture:** A new `scripts/lib/enrich.js` exposes `enrichSnapshot()` and is called from `scripts/fetch-sources.js` after per-source fetches but before writing the JSON file. `scripts/lib/socialdata-twitter.js` is extended to preserve fields the upstream API already returns. Two blog routes (`berkeley-rdi.js`, `baoyu.js`) are updated to set `full_text` directly from content they already hold, avoiding double-fetching.
+
+**Tech Stack:** Node 20 (via nvm, pinned in `.nvmrc`), pnpm, built-in `node --test`, existing `scripts/lib/http.js` for HTTP calls.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-enrichment-and-routine-slim-design.md`
+
+**Toolchain note:** Non-interactive shells (including Bash tool invocations) don't auto-source nvm. Prepend `source /opt/homebrew/opt/nvm/nvm.sh &&` to any command that needs node/pnpm (tests, install).
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `scripts/lib/enrich.js` | create | `jinaFetch()` + `enrichSnapshot()` — adds `full_text` / `linked_content` to articles |
+| `scripts/lib/enrich.test.js` | create | unit tests for jinaFetch + enrichSnapshot |
+| `scripts/lib/socialdata-twitter.js` | modify | preserve `expanded_urls`, `quoted_tweet`, `reply_to` from upstream response |
+| `scripts/lib/socialdata-twitter.test.js` | create | unit tests for the mapping from raw socialdata payload to article |
+| `scripts/fetch-sources.js` | modify | call `enrichSnapshot(output, sourceConfigs)` after per-source loop |
+| `scripts/routes/berkeley-rdi.js` | modify | set `full_text` directly from the jina-fetched body (no double-fetch) |
+| `scripts/routes/baoyu.js` | modify | pass `preserveContentEncoded: true` to `makeRssRoute` so `full_text` comes from `content:encoded` |
+| `scripts/lib/rss-route.js` | modify | accept `preserveContentEncoded` option; set `full_text` when present |
+| `CLAUDE.md` | modify | document the new fetch-cache schema fields |
+
+---
+
+## Task 1: Scaffold `scripts/lib/enrich.js` with `jinaFetch` helper (TDD)
+
+**Files:**
+- Create: `scripts/lib/enrich.js`
+- Create: `scripts/lib/enrich.test.js`
+
+- [ ] **Step 1: Write failing tests for `jinaFetch`**
+
+Create `scripts/lib/enrich.test.js`:
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { jinaFetch } = require('./enrich');
+
+// The default fetch function goes through the real Jina URL via the project's
+// fetchText helper. For unit tests we inject a stub via the second arg.
+
+test('jinaFetch: returns text on success, truncated to MAX_CHARS', async () => {
+  const big = 'x'.repeat(30_000);
+  const fetchStub = async (url) => {
+    assert.ok(url.startsWith('https://r.jina.ai/'), 'uses jina base');
+    return big;
+  };
+  const out = await jinaFetch('https://openai.com/index/foo', { fetchImpl: fetchStub });
+  assert.equal(out.length, 20_000);
+});
+
+test('jinaFetch: returns null on fetch error (does not throw)', async () => {
+  const fetchStub = async () => { throw new Error('HTTP 403'); };
+  const out = await jinaFetch('https://openai.com/index/foo', { fetchImpl: fetchStub });
+  assert.equal(out, null);
+});
+
+test('jinaFetch: returns null on timeout', async () => {
+  const fetchStub = async () => { throw new Error('timeout after 20s'); };
+  const out = await jinaFetch('https://openai.com/index/foo', { fetchImpl: fetchStub });
+  assert.equal(out, null);
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/enrich.test.js`
+
+Expected: all three fail with `Cannot find module './enrich'` (the module doesn't exist yet).
+
+- [ ] **Step 3: Write `jinaFetch` implementation**
+
+Create `scripts/lib/enrich.js`:
+
+```js
+const { fetchText } = require('./http');
+
+const JINA_BASE = 'https://r.jina.ai/';
+const MAX_CHARS = 20_000;
+
+async function jinaFetch(url, { fetchImpl } = {}) {
+  const impl = fetchImpl || ((u) => fetchText(u, { headers: { Accept: 'text/plain' } }));
+  try {
+    const text = await impl(JINA_BASE + url);
+    if (typeof text !== 'string') return null;
+    return text.slice(0, MAX_CHARS);
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { jinaFetch, JINA_BASE, MAX_CHARS };
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/enrich.test.js`
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/enrich.js scripts/lib/enrich.test.js
+git commit -m "feat(enrich): add jinaFetch helper with error-to-null conversion"
+```
+
+---
+
+## Task 2: `enrichSnapshot` for blog sources (TDD)
+
+**Files:**
+- Modify: `scripts/lib/enrich.js`
+- Modify: `scripts/lib/enrich.test.js`
+
+- [ ] **Step 1: Append failing tests for `enrichSnapshot` blog path**
+
+Add to `scripts/lib/enrich.test.js`:
+
+```js
+const { enrichSnapshot, BLOG_ENRICH_SOURCES } = require('./enrich');
+
+function makeSnapshot(extra = {}) {
+  return {
+    sources: {
+      'OpenAI Blog': {
+        status: 'ok',
+        articles: [
+          { title: 'hello', url: 'https://openai.com/index/hello',
+            published_at: '2026-04-22', description: 'short' },
+        ],
+      },
+      'Sam Altman (Twitter)': {
+        status: 'ok',
+        articles: [
+          { title: 'tweet', url: 'https://x.com/sama/status/1',
+            published_at: '2026-04-22', description: 'tweet text' },
+        ],
+      },
+      ...extra,
+    },
+  };
+}
+
+test('enrichSnapshot: blog source gets full_text, Twitter source untouched', async () => {
+  const snapshot = makeSnapshot();
+  const calls = [];
+  const fetchImpl = async (u) => { calls.push(u); return 'ENRICHED BODY'; };
+  await enrichSnapshot(snapshot, /* sourceConfigs */ [
+    { name: 'OpenAI Blog', role: 'primary' },
+    { name: 'Sam Altman (Twitter)', role: 'aggregator' },
+  ], { fetchImpl });
+  assert.equal(snapshot.sources['OpenAI Blog'].articles[0].full_text, 'ENRICHED BODY');
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].includes('/openai.com/index/hello'));
+  assert.equal('full_text' in snapshot.sources['Sam Altman (Twitter)'].articles[0], false);
+});
+
+test('enrichSnapshot: blog fetch failure → full_text null (no throw)', async () => {
+  const snapshot = makeSnapshot();
+  const fetchImpl = async () => { throw new Error('HTTP 403'); };
+  await enrichSnapshot(snapshot, [{ name: 'OpenAI Blog', role: 'primary' }], { fetchImpl });
+  assert.equal(snapshot.sources['OpenAI Blog'].articles[0].full_text, null);
+});
+
+test('enrichSnapshot: source with status error is skipped (no fetch, no full_text)', async () => {
+  const snapshot = {
+    sources: {
+      'OpenAI Blog': {
+        status: 'error', error: 'HTTP 500',
+        articles: [],  // real shape has empty articles on error
+      },
+    },
+  };
+  let called = false;
+  const fetchImpl = async () => { called = true; return 'x'; };
+  await enrichSnapshot(snapshot, [{ name: 'OpenAI Blog', role: 'primary' }], { fetchImpl });
+  assert.equal(called, false);
+});
+
+test('BLOG_ENRICH_SOURCES: exactly the five blog sources in the spec', () => {
+  assert.deepEqual([...BLOG_ENRICH_SOURCES].sort(), [
+    'Anthropic Blog', 'Anthropic Research', 'Google AI Blog', 'OpenAI Blog', 'The Batch',
+  ]);
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/enrich.test.js`
+
+Expected: 4 new tests fail (`enrichSnapshot`, `BLOG_ENRICH_SOURCES` not exported).
+
+- [ ] **Step 3: Implement `enrichSnapshot` blog path**
+
+Append to `scripts/lib/enrich.js` (before `module.exports`):
+
+```js
+const BLOG_ENRICH_SOURCES = new Set([
+  'OpenAI Blog', 'Google AI Blog', 'Anthropic Blog', 'Anthropic Research', 'The Batch',
+]);
+
+async function enrichSnapshot(snapshot, sourceConfigs, { fetchImpl } = {}) {
+  for (const [sourceName, entry] of Object.entries(snapshot.sources)) {
+    if (entry.status !== 'ok' && entry.status !== 'degraded_stale') continue;
+    if (!BLOG_ENRICH_SOURCES.has(sourceName)) continue;
+    for (const article of entry.articles) {
+      article.full_text = await jinaFetch(article.url, { fetchImpl });
+    }
+  }
+}
+```
+
+Update the `module.exports` line to also export `enrichSnapshot` and `BLOG_ENRICH_SOURCES`:
+
+```js
+module.exports = { jinaFetch, enrichSnapshot, BLOG_ENRICH_SOURCES, JINA_BASE, MAX_CHARS };
+```
+
+- [ ] **Step 4: Run tests, confirm all pass**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/enrich.test.js`
+
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/enrich.js scripts/lib/enrich.test.js
+git commit -m "feat(enrich): enrichSnapshot populates full_text for blog sources"
+```
+
+---
+
+## Task 3: Twitter route preserves expanded_urls / quoted_tweet / reply_to (TDD)
+
+**Files:**
+- Create: `scripts/lib/socialdata-twitter.test.js`
+- Modify: `scripts/lib/socialdata-twitter.js`
+
+- [ ] **Step 1: Write failing tests for field preservation**
+
+Create `scripts/lib/socialdata-twitter.test.js`:
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { mapTweetsToArticles } = require('./socialdata-twitter');
+
+// One raw socialdata tweet covering the "announcement + linked blog" pattern.
+const TWEET_WITH_URL_AND_QUOTE = {
+  id_str: '2046227759475921291',
+  full_text: '🚀 Introducing Qwen3.6-Max-Preview\nBlog: https://t.co/6hDQJhmkjM',
+  tweet_created_at: '2026-04-20T14:01:29.000Z',
+  user: { screen_name: 'Alibaba_Qwen' },
+  entities: {
+    urls: [
+      { url: 'https://t.co/6hDQJhmkjM',
+        expanded_url: 'https://qwenlm.github.io/blog/qwen3.6-max/',
+        display_url: 'qwenlm.github.io/blog/qwen3.6-m…' },
+    ],
+    user_mentions: [], hashtags: [], symbols: [],
+  },
+  is_quote_status: true,
+  quoted_status: {
+    id_str: '123456',
+    full_text: 'Scale matters.',
+    user: { screen_name: 'someoneelse' },
+  },
+  in_reply_to_status_id_str: null,
+  in_reply_to_screen_name: null,
+};
+
+const TWEET_PLAIN = {
+  id_str: '111',
+  full_text: 'just a tweet',
+  tweet_created_at: '2026-04-20T12:00:00.000Z',
+  user: { screen_name: 'sama' },
+  entities: { urls: [], user_mentions: [], hashtags: [], symbols: [] },
+  is_quote_status: false,
+  quoted_status: null,
+  in_reply_to_status_id_str: null,
+  in_reply_to_screen_name: null,
+};
+
+const TWEET_REPLY = {
+  id_str: '222',
+  full_text: 'yes exactly',
+  tweet_created_at: '2026-04-20T13:00:00.000Z',
+  user: { screen_name: 'sama' },
+  entities: { urls: [], user_mentions: [], hashtags: [], symbols: [] },
+  is_quote_status: false,
+  quoted_status: null,
+  in_reply_to_status_id_str: '2046000000000000000',
+  in_reply_to_screen_name: 'pg',
+};
+
+test('mapTweetsToArticles: preserves expanded_urls', () => {
+  const [a] = mapTweetsToArticles([TWEET_WITH_URL_AND_QUOTE], 'Alibaba_Qwen');
+  assert.deepEqual(a.expanded_urls, [
+    { t_co: 'https://t.co/6hDQJhmkjM',
+      expanded_url: 'https://qwenlm.github.io/blog/qwen3.6-max/',
+      display_url: 'qwenlm.github.io/blog/qwen3.6-m…' },
+  ]);
+});
+
+test('mapTweetsToArticles: preserves quoted_tweet when is_quote_status', () => {
+  const [a] = mapTweetsToArticles([TWEET_WITH_URL_AND_QUOTE], 'Alibaba_Qwen');
+  assert.deepEqual(a.quoted_tweet, {
+    author: 'someoneelse',
+    text: 'Scale matters.',
+    url: 'https://x.com/someoneelse/status/123456',
+  });
+});
+
+test('mapTweetsToArticles: quoted_tweet is null when not a quote-tweet', () => {
+  const [a] = mapTweetsToArticles([TWEET_PLAIN], 'sama');
+  assert.equal(a.quoted_tweet, null);
+});
+
+test('mapTweetsToArticles: reply_to set when in_reply_to_status_id_str present', () => {
+  const [a] = mapTweetsToArticles([TWEET_REPLY], 'sama');
+  assert.deepEqual(a.reply_to, { screen_name: 'pg', status_id: '2046000000000000000' });
+});
+
+test('mapTweetsToArticles: reply_to is null for non-reply tweets', () => {
+  const [a] = mapTweetsToArticles([TWEET_PLAIN], 'sama');
+  assert.equal(a.reply_to, null);
+});
+
+test('mapTweetsToArticles: existing fields (title, url, description, published_at) unchanged', () => {
+  const [a] = mapTweetsToArticles([TWEET_PLAIN], 'sama');
+  assert.equal(a.title, 'just a tweet');
+  assert.equal(a.url, 'https://x.com/sama/status/111');
+  assert.equal(a.description, 'just a tweet');
+  assert.equal(a.published_at, '2026-04-20T12:00:00.000Z');
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/socialdata-twitter.test.js`
+
+Expected: fails — `mapTweetsToArticles` is not yet exported.
+
+- [ ] **Step 3: Refactor `socialdata-twitter.js` to extract and export `mapTweetsToArticles`**
+
+Replace the file contents of `scripts/lib/socialdata-twitter.js`:
+
+```js
+const { fetchText } = require('./http');
+
+const BASE = 'https://api.socialdata.tools';
+
+function mapTweetsToArticles(tweets, handleFallback) {
+  return (tweets || []).map((t) => {
+    const screen = t.user?.screen_name || handleFallback;
+    const text = (t.full_text || t.text || '').trim();
+    const expandedUrls = (t.entities?.urls || []).map((u) => ({
+      t_co: u.url,
+      expanded_url: u.expanded_url,
+      display_url: u.display_url,
+    }));
+    const quotedTweet = (t.is_quote_status && t.quoted_status) ? {
+      author: t.quoted_status.user?.screen_name || null,
+      text: (t.quoted_status.full_text || t.quoted_status.text || '').trim(),
+      url: t.quoted_status.user?.screen_name && t.quoted_status.id_str
+        ? `https://x.com/${t.quoted_status.user.screen_name}/status/${t.quoted_status.id_str}`
+        : null,
+    } : null;
+    const replyTo = t.in_reply_to_status_id_str ? {
+      screen_name: t.in_reply_to_screen_name || null,
+      status_id: t.in_reply_to_status_id_str,
+    } : null;
+    return {
+      title: text.slice(0, 200),
+      url: `https://x.com/${screen}/status/${t.id_str}`,
+      published_at: t.tweet_created_at || null,
+      description: text,
+      expanded_urls: expandedUrls,
+      quoted_tweet: quotedTweet,
+      reply_to: replyTo,
+    };
+  });
+}
+
+function makeTwitterRoute({ name, handle, userId }) {
+  if (!handle) throw new Error(`socialdata-twitter: missing handle for ${name}`);
+  if (!userId) throw new Error(`socialdata-twitter: missing userId for ${name}`);
+  return {
+    name,
+    sourceType: 'socialdata',
+    sourceUrl: `https://x.com/${handle}`,
+    async fetch() {
+      const apiKey = process.env.SOCIALDATA_API_KEY;
+      if (!apiKey) return { articles: [], error: 'SOCIALDATA_API_KEY not set' };
+      try {
+        const body = await fetchText(`${BASE}/twitter/user/${userId}/tweets`, {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            Accept: 'application/json',
+          },
+        });
+        const data = JSON.parse(body);
+        const articles = mapTweetsToArticles(data.tweets, handle);
+        return { articles, error: null };
+      } catch (err) {
+        return { articles: [], error: err.message };
+      }
+    },
+  };
+}
+
+module.exports = { makeTwitterRoute, mapTweetsToArticles };
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/socialdata-twitter.test.js`
+
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/socialdata-twitter.js scripts/lib/socialdata-twitter.test.js
+git commit -m "feat(twitter): preserve expanded_urls, quoted_tweet, reply_to from socialdata response"
+```
+
+---
+
+## Task 4: `enrichSnapshot` linked_content for primary Twitter sources (TDD)
+
+**Files:**
+- Modify: `scripts/lib/enrich.js`
+- Modify: `scripts/lib/enrich.test.js`
+
+- [ ] **Step 1: Append failing tests for Twitter enrichment path**
+
+Add to `scripts/lib/enrich.test.js`:
+
+```js
+const { PRIMARY_BLOG_URL_PATTERNS } = require('./enrich');
+
+function makeTwitterSnapshot({ role, expandedUrls }) {
+  return {
+    sources: {
+      'Claude (Twitter)': {
+        status: 'ok',
+        articles: [
+          {
+            title: 'announcement',
+            url: 'https://x.com/claudeai/status/1',
+            published_at: '2026-04-22',
+            description: 'Read more: https://t.co/abc',
+            expanded_urls: expandedUrls,
+            quoted_tweet: null,
+            reply_to: null,
+          },
+        ],
+      },
+    },
+    _role: role,  // test-only convenience
+  };
+}
+
+test('enrichSnapshot: primary Twitter + matching primary blog URL → linked_content fetched', async () => {
+  const snapshot = makeTwitterSnapshot({
+    role: 'primary',
+    expandedUrls: [{ t_co: 'https://t.co/abc',
+      expanded_url: 'https://www.anthropic.com/news/cowork-live-artifacts',
+      display_url: 'anthropic.com/news/…' }],
+  });
+  const calls = [];
+  const fetchImpl = async (u) => { calls.push(u); return 'BLOG BODY'; };
+  await enrichSnapshot(snapshot,
+    [{ name: 'Claude (Twitter)', role: 'primary' }],
+    { fetchImpl });
+  assert.equal(snapshot.sources['Claude (Twitter)'].articles[0].linked_content, 'BLOG BODY');
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].includes('/anthropic.com/news/cowork-live-artifacts'));
+});
+
+test('enrichSnapshot: aggregator Twitter is never enriched', async () => {
+  const snapshot = makeTwitterSnapshot({
+    role: 'aggregator',
+    expandedUrls: [{ t_co: 'https://t.co/abc',
+      expanded_url: 'https://www.anthropic.com/news/foo',
+      display_url: 'anthropic.com/news/…' }],
+  });
+  let called = false;
+  const fetchImpl = async () => { called = true; return 'x'; };
+  await enrichSnapshot(snapshot,
+    [{ name: 'Claude (Twitter)', role: 'aggregator' }],
+    { fetchImpl });
+  assert.equal(called, false);
+  assert.equal('linked_content' in snapshot.sources['Claude (Twitter)'].articles[0], false);
+});
+
+test('enrichSnapshot: primary Twitter with no matching URL → linked_content null', async () => {
+  const snapshot = makeTwitterSnapshot({
+    role: 'primary',
+    expandedUrls: [{ t_co: 'https://t.co/abc',
+      expanded_url: 'https://random-blog.example.com/foo',
+      display_url: 'random-blog.example.com/foo' }],
+  });
+  let called = false;
+  const fetchImpl = async () => { called = true; return 'x'; };
+  await enrichSnapshot(snapshot,
+    [{ name: 'Claude (Twitter)', role: 'primary' }],
+    { fetchImpl });
+  assert.equal(called, false);
+  assert.equal(snapshot.sources['Claude (Twitter)'].articles[0].linked_content, null);
+});
+
+test('enrichSnapshot: stops at first matching URL (one jina call per tweet)', async () => {
+  const snapshot = makeTwitterSnapshot({
+    role: 'primary',
+    expandedUrls: [
+      { t_co: 'a', expanded_url: 'https://www.anthropic.com/news/one', display_url: '' },
+      { t_co: 'b', expanded_url: 'https://openai.com/index/two', display_url: '' },
+    ],
+  });
+  const calls = [];
+  const fetchImpl = async (u) => { calls.push(u); return 'x'; };
+  await enrichSnapshot(snapshot,
+    [{ name: 'Claude (Twitter)', role: 'primary' }],
+    { fetchImpl });
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].includes('anthropic.com/news/one'));
+});
+
+test('PRIMARY_BLOG_URL_PATTERNS matches expected hosts', () => {
+  const matchers = PRIMARY_BLOG_URL_PATTERNS;
+  const match = (u) => matchers.some((re) => re.test(u));
+  assert.ok(match('https://www.anthropic.com/news/foo'));
+  assert.ok(match('https://www.anthropic.com/research/bar'));
+  assert.ok(match('https://openai.com/index/x'));
+  assert.ok(match('https://openai.com/research/y'));
+  assert.ok(match('https://openai.com/blog/z'));
+  assert.ok(match('https://blog.google/technology/ai/something/'));
+  assert.ok(match('https://deepmind.google/discover/blog/foo/'));
+  assert.ok(match('https://www.deeplearning.ai/the-batch/issue-350/'));
+  assert.equal(match('https://random.example.com/foo'), false);
+  assert.equal(match('https://twitter.com/AnthropicAI/status/123'), false);
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/enrich.test.js`
+
+Expected: 5 new tests fail (`PRIMARY_BLOG_URL_PATTERNS` not exported; Twitter path not implemented).
+
+- [ ] **Step 3: Add primary-URL patterns and extend `enrichSnapshot`**
+
+In `scripts/lib/enrich.js`, add `PRIMARY_BLOG_URL_PATTERNS` below the existing constants:
+
+```js
+const PRIMARY_BLOG_URL_PATTERNS = [
+  /^https?:\/\/(www\.)?anthropic\.com\/(news|research)\//,
+  /^https?:\/\/(www\.)?openai\.com\/(index|research|blog)\//,
+  /^https?:\/\/blog\.google\//,
+  /^https?:\/\/(www\.)?deepmind\.google\//,
+  /^https?:\/\/(www\.)?deeplearning\.ai\/the-batch\//,
+];
+
+function isPrimaryBlogUrl(url) {
+  return typeof url === 'string' && PRIMARY_BLOG_URL_PATTERNS.some((re) => re.test(url));
+}
+```
+
+Replace `enrichSnapshot` body with the combined blog + Twitter version:
+
+```js
+async function enrichSnapshot(snapshot, sourceConfigs, { fetchImpl } = {}) {
+  const roleByName = Object.fromEntries((sourceConfigs || []).map((s) => [s.name, s.role]));
+  for (const [sourceName, entry] of Object.entries(snapshot.sources)) {
+    if (entry.status !== 'ok' && entry.status !== 'degraded_stale') continue;
+
+    const isBlog = BLOG_ENRICH_SOURCES.has(sourceName);
+    const isTwitterPrimary = /\(Twitter\)$/.test(sourceName) && roleByName[sourceName] === 'primary';
+    if (!isBlog && !isTwitterPrimary) continue;
+
+    for (const article of entry.articles) {
+      if (isBlog) {
+        article.full_text = await jinaFetch(article.url, { fetchImpl });
+      }
+      if (isTwitterPrimary) {
+        article.linked_content = null;
+        for (const { expanded_url } of (article.expanded_urls || [])) {
+          if (isPrimaryBlogUrl(expanded_url)) {
+            article.linked_content = await jinaFetch(expanded_url, { fetchImpl });
+            break;
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Update the `module.exports`:
+
+```js
+module.exports = {
+  jinaFetch, enrichSnapshot,
+  BLOG_ENRICH_SOURCES, PRIMARY_BLOG_URL_PATTERNS,
+  JINA_BASE, MAX_CHARS,
+};
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/enrich.test.js`
+
+Expected: 12 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/enrich.js scripts/lib/enrich.test.js
+git commit -m "feat(enrich): follow primary-blog expanded_urls for primary Twitter sources"
+```
+
+---
+
+## Task 5: Wire `enrichSnapshot` into `scripts/fetch-sources.js`
+
+**Files:**
+- Modify: `scripts/fetch-sources.js`
+
+- [ ] **Step 1: Import `enrichSnapshot`**
+
+At the top of `scripts/fetch-sources.js`, below the existing `require('./routes')` line, add:
+
+```js
+const { enrichSnapshot } = require('./lib/enrich');
+```
+
+- [ ] **Step 2: Call `enrichSnapshot` after the per-source loop, before writing JSON**
+
+In `scripts/fetch-sources.js`, locate the block that currently reads:
+
+```js
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  const outPath = path.join(CACHE_DIR, `${shanghaiDateStr(fetchedAt)}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(output, null, 2) + '\n');
+```
+
+Replace with:
+
+```js
+  console.error('enriching articles via Jina Reader...');
+  await enrichSnapshot(output, sourceConfigs);
+  console.error('enrichment done');
+
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  const outPath = path.join(CACHE_DIR, `${shanghaiDateStr(fetchedAt)}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(output, null, 2) + '\n');
+```
+
+- [ ] **Step 3: Verify by dry-running locally (only Twitter sources, fast)**
+
+We don't want to fire real jina fetches across all 5 blog sources during development. Instead, sanity-check that the new call doesn't crash on a config-only snapshot. Run:
+
+```bash
+source /opt/homebrew/opt/nvm/nvm.sh && SOCIALDATA_API_KEY= node scripts/fetch-sources.js 2>&1 | tail -30
+```
+
+Expected output includes:
+- Per-source fetch lines
+- A single `enriching articles via Jina Reader...` line
+- A single `enrichment done` line
+- `wrote data/fetch-cache/YYYY-MM-DD.json`
+
+If jina is reachable, blog sources with new articles in the window will get full_text populated. If jina is unreachable from your dev machine, they'll be null (expected; non-fatal).
+
+- [ ] **Step 4: Inspect the produced fetch-cache**
+
+```bash
+cat data/fetch-cache/$(TZ=Asia/Shanghai date +%Y-%m-%d).json | head -80
+```
+
+Expected: at least one blog-source article now has a `"full_text": "..."` or `"full_text": null` field. Twitter articles (if any) show `expanded_urls`, `quoted_tweet`, `reply_to` fields.
+
+- [ ] **Step 5: Revert the transient cache file so it doesn't pollute git**
+
+```bash
+git checkout -- data/fetch-cache/
+```
+
+(It's fine to leave the real daily-fetch GH Actions run to produce the first "live" enriched snapshot tomorrow.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/fetch-sources.js
+git commit -m "feat(fetch): wire enrichSnapshot into the daily-fetch pipeline"
+```
+
+---
+
+## Task 6: Berkeley RDI route — set `full_text` directly (no double-fetch)
+
+**Files:**
+- Modify: `scripts/routes/berkeley-rdi.js`
+
+- [ ] **Step 1: Inspect current route**
+
+Read `scripts/routes/berkeley-rdi.js`. Each post `p` has fields including `truncated_body_text`, which is already used for `description`. Substack's archive JSON also returns `body_html` on many endpoints, but here we only have what `/api/v1/archive` provides.
+
+For Berkeley RDI, the richest body we already have without another fetch is `truncated_body_text`. This is strictly more content than `description` (which is `subtitle || description || truncated_body_text`). Wire it into `full_text` as a zero-cost upgrade.
+
+- [ ] **Step 2: Modify the route to set `full_text`**
+
+In `scripts/routes/berkeley-rdi.js`, replace the `articles = posts.map(...)` block with:
+
+```js
+      const articles = posts.map((p) => ({
+        title: (p.title || '').trim(),
+        url: p.canonical_url || `${CANONICAL_BASE}/p/${p.slug}`,
+        published_at: p.post_date || null,
+        description: (p.subtitle || p.description || p.truncated_body_text || '').trim().slice(0, 500) || null,
+        full_text: (p.truncated_body_text || p.description || '').trim() || null,
+      }));
+```
+
+- [ ] **Step 3: Verify no regressions**
+
+Berkeley RDI doesn't currently have route-level tests; it's exercised through the daily-fetch pipeline. Smoke-test the change:
+
+```bash
+source /opt/homebrew/opt/nvm/nvm.sh && node -e "
+(async () => {
+  const r = require('./scripts/routes/berkeley-rdi');
+  const out = await r.fetch();
+  console.log('articles:', out.articles.length, 'error:', out.error);
+  if (out.articles[0]) {
+    console.log('has full_text:', typeof out.articles[0].full_text);
+    console.log('full_text length:', (out.articles[0].full_text || '').length);
+  }
+})();
+"
+```
+
+Expected: `articles: N, error: null` with `full_text` present and non-empty on at least one article. If jina or Substack is unreachable, you'll see an error message — that's the existing behavior, unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/routes/berkeley-rdi.js
+git commit -m "feat(berkeley-rdi): set full_text from truncated_body_text (no double-fetch)"
+```
+
+---
+
+## Task 7: Baoyu route + rss-route — preserve `content:encoded` as `full_text`
+
+**Files:**
+- Modify: `scripts/lib/rss-route.js`
+- Modify: `scripts/routes/baoyu.js`
+
+- [ ] **Step 1: Inspect what rss-parser returns for baoyu feed**
+
+Run:
+
+```bash
+source /opt/homebrew/opt/nvm/nvm.sh && node -e "
+(async () => {
+  const { fetchText } = require('./scripts/lib/http');
+  const { parseRss } = require('./scripts/lib/xml');
+  const xml = await fetchText('https://baoyu.io/feed.xml');
+  const feed = await parseRss(xml);
+  const item = feed.items[0];
+  console.log('keys:', Object.keys(item));
+  console.log('content length:', (item.content || '').length);
+  console.log('content:encoded length:', (item['content:encoded'] || '').length);
+  console.log('contentSnippet length:', (item.contentSnippet || '').length);
+})();
+"
+```
+
+Expected output: a list of keys including `content` and possibly `content:encoded`. rss-parser by default aliases `content:encoded` to `content` if present. The `content` field will be multi-KB HTML for baoyu.
+
+- [ ] **Step 2: Extend `makeRssRoute` to optionally set `full_text` from `content`**
+
+In `scripts/lib/rss-route.js`, replace the whole file with:
+
+```js
+const { fetchText } = require('./http');
+const { parseRss } = require('./xml');
+
+function makeRssRoute({ name, sourceUrl, preserveContent = false }) {
+  return {
+    name,
+    sourceType: 'rss',
+    sourceUrl,
+    async fetch() {
+      try {
+        const xml = await fetchText(sourceUrl);
+        const feed = await parseRss(xml);
+        const articles = (feed.items || []).map((item) => {
+          const isoDate = item.isoDate || (item.pubDate ? new Date(item.pubDate).toISOString() : null);
+          const article = {
+            title: (item.title || '').trim(),
+            url: item.link || '',
+            published_at: isoDate,
+            description: (item.contentSnippet || item.content || item.description || '').trim(),
+          };
+          if (preserveContent) {
+            const body = (item['content:encoded'] || item.content || '').trim();
+            article.full_text = body || null;
+          }
+          return article;
+        });
+        return { articles, error: null };
+      } catch (err) {
+        return { articles: [], error: err.message };
+      }
+    },
+  };
+}
+
+module.exports = { makeRssRoute };
+```
+
+- [ ] **Step 3: Pass `preserveContent: true` from the baoyu route**
+
+In `scripts/routes/baoyu.js`, replace with:
+
+```js
+const { makeRssRoute } = require('../lib/rss-route');
+
+module.exports = makeRssRoute({
+  name: '宝玉的分享',
+  sourceUrl: 'https://baoyu.io/feed.xml',
+  preserveContent: true,
+});
+```
+
+- [ ] **Step 4: Smoke-test**
+
+```bash
+source /opt/homebrew/opt/nvm/nvm.sh && node -e "
+(async () => {
+  const r = require('./scripts/routes/baoyu');
+  const out = await r.fetch();
+  console.log('articles:', out.articles.length, 'error:', out.error);
+  console.log('first article has full_text:', typeof out.articles[0]?.full_text);
+  console.log('full_text length:', (out.articles[0]?.full_text || '').length);
+})();
+"
+```
+
+Expected: `articles: N, error: null` with `full_text` of non-trivial length (typically >1KB for baoyu posts).
+
+- [ ] **Step 5: Verify other rss routes (OpenAI Blog, Google AI Blog) are unaffected**
+
+They call `makeRssRoute` without `preserveContent`. Check:
+
+```bash
+source /opt/homebrew/opt/nvm/nvm.sh && node -e "
+(async () => {
+  const r = require('./scripts/routes/openai-blog');
+  const out = await r.fetch();
+  const a = out.articles[0];
+  console.log('has full_text field:', 'full_text' in (a || {}));
+})();
+"
+```
+
+Expected: `has full_text field: false` — confirms route is untouched (enrichSnapshot will later populate `full_text` for OpenAI Blog via jina).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/rss-route.js scripts/routes/baoyu.js
+git commit -m "feat(baoyu): preserve content:encoded as full_text via rss-route option"
+```
+
+---
+
+## Task 8: Document new fetch-cache fields in `CLAUDE.md`
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Locate the schema section to extend**
+
+In `CLAUDE.md`, find the bullet that describes fetch-cache articles. It currently reads (section "Rules for Trigger Agents" → "Fetching"):
+
+```
+- `articles`: list of `{ title, url, published_at, description }` (already pre-filtered to `window_hours` of recency...)
+```
+
+- [ ] **Step 2: Extend the schema bullet**
+
+Replace that line with:
+
+```
+- `articles`: list of `{ title, url, published_at, description, full_text?, linked_content?, expanded_urls?, quoted_tweet?, reply_to? }` — already pre-filtered to `window_hours` of recency (overlap with yesterday is handled by URL-hash dedup in history.json).
+  - `full_text` (blog sources): full article body (markdown from Jina Reader or upstream HTML). Null when enrichment failed. Absent for Twitter sources.
+  - `linked_content` (primary Twitter sources only): Jina-fetched body of the primary-blog URL the tweet links to, when one exists. Null when no matching URL or fetch failed.
+  - `expanded_urls` (Twitter): `[{ t_co, expanded_url, display_url }]` from `entities.urls`.
+  - `quoted_tweet` (Twitter): `{ author, text, url }` when the tweet is a quote-tweet, else null.
+  - `reply_to` (Twitter): `{ screen_name, status_id }` when the tweet is a reply, else null.
+  - **Summary-source priority when analyzing:** `linked_content` > `full_text` > `quoted_tweet.text + description` > `description`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document enriched fetch-cache fields and summary-source priority"
+```
+
+---
+
+## Task 9: End-to-end verification (manual)
+
+**No file changes** — this step confirms the PR is ready to open.
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/
+```
+
+Expected: all test files pass (enrich, socialdata-twitter, email-reports). Count roughly 20+ tests green.
+
+- [ ] **Step 2: Dry-run `fetch-sources.js`**
+
+Skip Twitter (no API key) but let blog sources actually fetch + enrich:
+
+```bash
+source /opt/homebrew/opt/nvm/nvm.sh && SOCIALDATA_API_KEY= node scripts/fetch-sources.js 2>&1 | grep -E '(ok|ERROR|enrich|wrote)'
+```
+
+Expected: each blog source has at least one article (or `filtered_count: 0` on quiet days), enrichment runs once, cache file written.
+
+- [ ] **Step 3: Inspect the produced cache for schema correctness**
+
+```bash
+node -e "
+const s = require('./data/fetch-cache/' + new Intl.DateTimeFormat('sv-SE',{timeZone:'Asia/Shanghai',year:'numeric',month:'2-digit',day:'2-digit'}).format(new Date()) + '.json');
+const summary = {};
+for (const [name, e] of Object.entries(s.sources)) {
+  summary[name] = {
+    status: e.status,
+    n: e.articles.length,
+    has_full_text: e.articles.filter(a => 'full_text' in a).length,
+    has_expanded_urls: e.articles.filter(a => 'expanded_urls' in a).length,
+  };
+}
+console.log(JSON.stringify(summary, null, 2));
+"
+```
+
+Expected: blog sources (OpenAI Blog, etc.) show `has_full_text: N`; Twitter sources (if any articles present) show `has_expanded_urls: N`. 宝玉的分享 shows `has_full_text: N` regardless of enrichment.
+
+- [ ] **Step 4: Clean up and check git status**
+
+```bash
+git checkout -- data/fetch-cache/
+git status
+```
+
+Expected: working tree clean (all commits made).
+
+- [ ] **Step 5: Open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(enrich): Jina enrichment + Twitter field preservation" --body "$(cat <<'EOF'
+## Summary
+- New scripts/lib/enrich.js: jinaFetch + enrichSnapshot
+- Blog sources (OpenAI Blog, Google AI Blog, Anthropic Blog, Anthropic Research, The Batch) get full_text via Jina Reader
+- Twitter routes preserve expanded_urls, quoted_tweet, reply_to from socialdata response
+- Primary Twitter sources (Claude, Anthropic, OpenAI, OpenAI Devs, GoogleDeepMind, Meta AI, Mistral, xAI, DeepSeek, Qwen) follow expanded_urls matching known primary-blog patterns → linked_content
+- Berkeley RDI sets full_text from truncated_body_text (no double-fetch through jina)
+- 宝玉的分享 preserves content:encoded as full_text via new rss-route option
+- Spec: docs/superpowers/specs/2026-04-22-enrichment-and-routine-slim-design.md (Phase 1)
+
+## Test plan
+- [x] scripts/lib/enrich.test.js passes
+- [x] scripts/lib/socialdata-twitter.test.js passes
+- [x] Local fetch-sources.js run produces enriched fetch-cache with expected fields
+- [ ] First daily-fetch GH Actions run after merge shows enriched fetch-cache on origin
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review checklist (for writer)
+
+**Spec § coverage:**
+- § 5.1 scope table → Tasks 2, 4, 6, 7 ✓
+- § 5.2 enrich.js sketch → Tasks 1, 2, 4 ✓
+- § 5.2 socialdata-twitter.js changes → Task 3 ✓
+- § 5.3 schema changes → Task 8 (docs) ✓
+- § 5.4 failure modes (null on error) → asserted in Tasks 1, 2, 4 ✓
+- § 10 open question on 宝玉 → Task 7 ✓
+
+**Placeholder scan:** none (every code step includes the actual code).
+
+**Identifier consistency:** `enrichSnapshot`, `jinaFetch`, `BLOG_ENRICH_SOURCES`, `PRIMARY_BLOG_URL_PATTERNS`, `mapTweetsToArticles`, `preserveContent` are used identically across tasks.

--- a/docs/superpowers/plans/2026-04-22-routine-slim-plan.md
+++ b/docs/superpowers/plans/2026-04-22-routine-slim-plan.md
@@ -1,0 +1,1623 @@
+# CatchUp Routine Slim-Down Implementation Plan (PR 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Shrink the Claude Cloud Scheduled Trigger's prompt from 11 sequential steps to 1 (produce a structured analysis JSON), moving all deterministic work (markdown rendering, history/health updates, gh-issue alerts, commit+push) into `scripts/build-report.js` (new) which runs in GH Actions. Add `scripts/fallback-report.js` (cron, +4h after fetch) as a guaranteed-delivery floor.
+
+**Architecture:** Daily trigger writes `data/analysis-cache/{date}.json` with per-article analyses + trend paragraph, commits, exits. A push to `data/analysis-cache/**` fires `.github/workflows/build-report.yml`, which reads fetch-cache + analysis-cache, renders the markdown report, and updates history/health/issues. A separate `.github/workflows/fallback-report.yml` runs at 12:00 CST daily; if no report for today exists, it renders a title-only report from fetch-cache.
+
+**Tech Stack:** Node 20 (via nvm), pnpm, built-in `node --test`, existing `scripts/lib/http.js`, `gh` CLI for issue management, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-enrichment-and-routine-slim-design.md`
+
+**Depends on:** PR 1 (enrichment) must be merged first. The slim prompt's summary-source priority references `linked_content` / `full_text` from PR 1.
+
+**Toolchain note:** Prepend `source /opt/homebrew/opt/nvm/nvm.sh &&` to any command that needs node/pnpm.
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `data/analysis-cache/.gitkeep` | create | new directory the trigger writes to |
+| `scripts/build-report.js` | create | deterministic post-processor: render report + update history/health/issues + commit+push |
+| `scripts/build-report.test.js` | create | unit tests (rendering, dedup, thread merge, retention, health state machine) |
+| `scripts/lib/render-report.js` | create | pure markdown-rendering function, exported for tests |
+| `scripts/lib/render-report.test.js` | create | unit tests for markdown rendering |
+| `scripts/lib/health.js` | create | pure health-state-machine function, exported for tests |
+| `scripts/lib/health.test.js` | create | unit tests for health transitions |
+| `scripts/fallback-report.js` | create | guaranteed-delivery floor: render title-only report if normal one is missing |
+| `scripts/fallback-report.test.js` | create | unit tests |
+| `.github/workflows/build-report.yml` | create | triggers on push to `data/analysis-cache/**` |
+| `.github/workflows/fallback-report.yml` | create | daily cron at 04:00 UTC (12:00 CST); also manual dispatch |
+| `docs/prompts/daily-trigger.md` | rewrite | slim prompt producing analysis-cache JSON only |
+| `.claude/skills/sync-daily-trigger/SKILL.md` | modify | note the new prompt shape (behavioral change, not procedure change) |
+| `CLAUDE.md` | modify | update pipeline description for the new two-step flow |
+
+---
+
+## Task 1: Scaffold `data/analysis-cache/` directory
+
+**Files:**
+- Create: `data/analysis-cache/.gitkeep`
+
+- [ ] **Step 1: Create the directory with a keep file**
+
+```bash
+mkdir -p data/analysis-cache && touch data/analysis-cache/.gitkeep
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add data/analysis-cache/.gitkeep
+git commit -m "chore: scaffold data/analysis-cache/ for slim-trigger output"
+```
+
+---
+
+## Task 2: `scripts/lib/render-report.js` — pure markdown rendering (TDD)
+
+**Files:**
+- Create: `scripts/lib/render-report.js`
+- Create: `scripts/lib/render-report.test.js`
+
+The current daily-trigger prompt relies on Claude freehand-rendering the markdown following the example. We lock that format into a pure function here so both `build-report.js` and tests produce identical output.
+
+- [ ] **Step 1: Write failing tests for article block rendering**
+
+Create `scripts/lib/render-report.test.js`:
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { renderArticleBlock, renderReport, CATEGORIES } = require('./render-report');
+
+const SAMPLE_ARTICLE = {
+  title: 'Introducing Claude Opus 4.7',
+  url: 'https://www.anthropic.com/news/claude-opus-4-7',
+  source: 'Anthropic Blog',
+  category: '模型发布',
+  importance: 5,
+  tags: ['Claude', 'Opus', '模型发布'],
+  summary: 'Anthropic 发布 Claude Opus 4.7，在 reasoning 与工具使用上较 4.6 显著提升。',
+  practice_suggestions: ['在 Claude.ai 切换到 Opus 4.7 运行一组你已有的编码基准', '对比 Sonnet 4.6 的成本差'],
+};
+
+test('renderArticleBlock: includes title as link, source, category, stars, tags', () => {
+  const md = renderArticleBlock(SAMPLE_ARTICLE, 1);
+  assert.match(md, /### 1\. \[Introducing Claude Opus 4\.7\]\(https:\/\/www\.anthropic\.com\/news\/claude-opus-4-7\)/);
+  assert.match(md, /- \*\*来源\*\*: Anthropic Blog/);
+  assert.match(md, /- \*\*分类\*\*: 模型发布/);
+  assert.match(md, /- \*\*重要性\*\*: ⭐⭐⭐⭐⭐ \(5\/5\)/);
+  assert.match(md, /- \*\*标签\*\*: `Claude` `Opus` `模型发布`/);
+  assert.match(md, /\*\*摘要\*\*: Anthropic 发布 Claude Opus 4\.7/);
+});
+
+test('renderArticleBlock: emits practice_suggestions as blockquote when present', () => {
+  const md = renderArticleBlock(SAMPLE_ARTICLE, 1);
+  assert.match(md, /> \*\*实践建议\*\*/);
+  assert.match(md, /> - 在 Claude\.ai 切换到 Opus 4\.7/);
+  assert.match(md, /> - 对比 Sonnet 4\.6 的成本差/);
+});
+
+test('renderArticleBlock: omits practice_suggestions block when absent', () => {
+  const a = { ...SAMPLE_ARTICLE, practice_suggestions: null };
+  const md = renderArticleBlock(a, 1);
+  assert.doesNotMatch(md, /实践建议/);
+});
+
+test('renderArticleBlock: adds "也被 X, Y 报道" when also_covered_by present', () => {
+  const a = { ...SAMPLE_ARTICLE, also_covered_by: ['Berkeley RDI', 'The Batch'] };
+  const md = renderArticleBlock(a, 1);
+  assert.match(md, /\| 📡 也被 Berkeley RDI, The Batch 报道/);
+});
+
+test('CATEGORIES: matches config category order', () => {
+  assert.deepEqual(CATEGORIES, ['模型发布', '研究', '产品与功能', '商业动态', '政策与安全', '教程与观点']);
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/render-report.test.js`
+
+Expected: fails — module doesn't exist.
+
+- [ ] **Step 3: Implement `renderArticleBlock`**
+
+Create `scripts/lib/render-report.js`:
+
+```js
+const CATEGORIES = ['模型发布', '研究', '产品与功能', '商业动态', '政策与安全', '教程与观点'];
+
+function stars(n) { return '⭐'.repeat(Math.max(1, Math.min(5, n))); }
+
+function renderArticleBlock(a, idx) {
+  const sourceLine = a.also_covered_by?.length
+    ? `- **来源**: ${a.source} | 📡 也被 ${a.also_covered_by.join(', ')} 报道\n`
+    : `- **来源**: ${a.source}\n`;
+  const tags = (a.tags || []).map((t) => '`' + t + '`').join(' ');
+  let md = '';
+  md += `### ${idx}. [${a.title}](${a.url})\n\n`;
+  md += sourceLine;
+  md += `- **分类**: ${a.category}\n`;
+  md += `- **重要性**: ${stars(a.importance)} (${a.importance}/5)\n`;
+  md += `- **标签**: ${tags}\n\n`;
+  md += `**摘要**: ${a.summary}\n\n`;
+  if (a.practice_suggestions && a.practice_suggestions.length) {
+    md += '> **实践建议**\n';
+    for (const s of a.practice_suggestions) md += `> - ${s}\n`;
+    md += '\n';
+  }
+  md += '---\n\n';
+  return md;
+}
+
+module.exports = { renderArticleBlock, CATEGORIES };
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/render-report.test.js`
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/render-report.js scripts/lib/render-report.test.js
+git commit -m "feat(render-report): extract article-block rendering as pure function"
+```
+
+---
+
+## Task 3: `renderReport` — full daily report rendering (TDD)
+
+**Files:**
+- Modify: `scripts/lib/render-report.js`
+- Modify: `scripts/lib/render-report.test.js`
+
+- [ ] **Step 1: Append failing tests for `renderReport`**
+
+Add to `scripts/lib/render-report.test.js`:
+
+```js
+function makeArticle(n, overrides = {}) {
+  return {
+    title: `文章 ${n}`,
+    url: `https://example.com/${n}`,
+    source: 'OpenAI Blog',
+    category: '模型发布',
+    importance: 3,
+    tags: ['t1'],
+    summary: `摘要 ${n}`,
+    ...overrides,
+  };
+}
+
+test('renderReport: header with date + totals + category table', () => {
+  const md = renderReport({
+    date: '2026-04-22',
+    articlesInReport: [makeArticle(1), makeArticle(2, { category: '研究' })],
+    rawFetched: 10,
+    mergedCount: 7,
+    sourcesWithContent: 3,
+    filteredLowImportance: 2,
+    trendParagraph: '今日主题是模型更新。',
+    sourceStatuses: [
+      { name: 'OpenAI Blog', status_note: '✅ 正常（窗口内 2 文）' },
+      { name: 'Google AI Blog', status_note: '✅ 正常（窗口内 0 文）' },
+    ],
+  });
+  assert.match(md, /^# CatchUp 日报 — 2026-04-22/);
+  assert.match(md, /共抓取 \*\*10\*\* 篇文章/);
+  assert.match(md, /合并多推文线程后为 7 条/);
+  assert.match(md, /来自 \*\*3\*\* 个数据源/);
+  assert.match(md, /过滤后在报告中展示 \*\*2\*\* 篇/);
+  assert.match(md, /\| 模型发布 \| 1 \|/);
+  assert.match(md, /\| 研究 \| 1 \|/);
+  assert.match(md, /\| 产品与功能 \| 0 \|/);
+});
+
+test('renderReport: includes each article in body, trend, source status table', () => {
+  const md = renderReport({
+    date: '2026-04-22',
+    articlesInReport: [makeArticle(1)],
+    rawFetched: 1, mergedCount: 1, sourcesWithContent: 1,
+    filteredLowImportance: 0,
+    trendParagraph: '今日 trend.',
+    sourceStatuses: [{ name: 'OpenAI Blog', status_note: '✅ 正常（窗口内 1 文）' }],
+  });
+  assert.match(md, /### 1\. \[文章 1\]/);
+  assert.match(md, /## 今日趋势[\s\S]*?今日 trend\./);
+  assert.match(md, /## 数据源状态[\s\S]*?\| OpenAI Blog \| ✅ 正常/);
+  assert.match(md, /共过滤 0 篇低重要度条目/);
+});
+
+test('renderReport: zero-article day renders placeholder section', () => {
+  const md = renderReport({
+    date: '2026-04-22',
+    articlesInReport: [],
+    rawFetched: 0, mergedCount: 0, sourcesWithContent: 0,
+    filteredLowImportance: 0,
+    trendParagraph: '今日所有数据源窗口内均无新内容。',
+    sourceStatuses: [{ name: 'OpenAI Blog', status_note: '✅ 正常（窗口内 0 文）' }],
+  });
+  assert.match(md, /今日 30h 抓取窗口内全部 \d+ 个数据源均未产出新内容/);
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/render-report.test.js`
+
+Expected: 3 new tests fail — `renderReport` not exported.
+
+- [ ] **Step 3: Implement `renderReport`**
+
+Append to `scripts/lib/render-report.js` (before `module.exports`):
+
+```js
+function renderReport({
+  date,
+  articlesInReport,
+  rawFetched,
+  mergedCount,
+  sourcesWithContent,
+  filteredLowImportance,
+  trendParagraph,
+  sourceStatuses,
+}) {
+  const catCounts = Object.fromEntries(CATEGORIES.map((c) => [c, 0]));
+  for (const a of articlesInReport) {
+    if (catCounts[a.category] !== undefined) catCounts[a.category]++;
+  }
+
+  let md = '';
+  md += `# CatchUp 日报 — ${date}\n\n## 今日概览\n\n`;
+  if (mergedCount === rawFetched) {
+    md += `共抓取 **${rawFetched}** 篇文章，来自 **${sourcesWithContent}** 个数据源（过滤后在报告中展示 **${articlesInReport.length}** 篇）。\n\n`;
+  } else {
+    md += `共抓取 **${rawFetched}** 篇文章（合并多推文线程后为 ${mergedCount} 条独立条目），来自 **${sourcesWithContent}** 个数据源（过滤后在报告中展示 **${articlesInReport.length}** 篇）。\n\n`;
+  }
+  md += '| 分类 | 数量 |\n|------|------|\n';
+  for (const c of CATEGORIES) md += `| ${c} | ${catCounts[c]} |\n`;
+  md += '\n---\n\n## 文章详情\n\n';
+
+  if (articlesInReport.length === 0) {
+    md += `今日 30h 抓取窗口内全部 ${sourceStatuses.length} 个数据源均未产出新内容，无条目可展示。\n\n---\n\n`;
+  } else {
+    articlesInReport.forEach((a, i) => { md += renderArticleBlock(a, i + 1); });
+  }
+
+  md += '## 今日趋势\n\n';
+  md += trendParagraph.trim() + '\n\n';
+  md += '---\n\n## 数据源状态\n\n| 数据源 | 状态 |\n|--------|------|\n';
+  for (const s of sourceStatuses) md += `| ${s.name} | ${s.status_note} |\n`;
+  md += `\n注：共过滤 ${filteredLowImportance} 篇低重要度条目（importance < 2）——这些条目仍记入 history.json。\n`;
+  return md;
+}
+```
+
+Update `module.exports`:
+
+```js
+module.exports = { renderArticleBlock, renderReport, CATEGORIES };
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/render-report.test.js`
+
+Expected: 8 tests pass (5 from Task 2 + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/render-report.js scripts/lib/render-report.test.js
+git commit -m "feat(render-report): renderReport assembles full daily report markdown"
+```
+
+---
+
+## Task 4: `scripts/lib/health.js` — pure state-machine function (TDD)
+
+**Files:**
+- Create: `scripts/lib/health.js`
+- Create: `scripts/lib/health.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `scripts/lib/health.test.js`:
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { updateSourceHealth } = require('./health');
+
+const NOW = '2026-04-22T00:09:08Z';
+const THRESHOLD = 3;
+
+test('ok status → healthy, consecutive_failures reset', () => {
+  const prior = { status: 'degraded', last_success: '2026-04-18T00:00:00Z', consecutive_failures: 2, last_error: 'old error' };
+  const fc = { status: 'ok', error: null };
+  const next = updateSourceHealth(prior, fc, NOW, THRESHOLD);
+  assert.deepEqual(next, {
+    status: 'healthy', last_success: NOW, consecutive_failures: 0, last_error: null,
+  });
+});
+
+test('error status → degraded when below threshold, increments failures, copies error', () => {
+  const prior = { status: 'healthy', last_success: '2026-04-20T00:00:00Z', consecutive_failures: 0, last_error: null };
+  const fc = { status: 'error', error: 'HTTP 500' };
+  const next = updateSourceHealth(prior, fc, NOW, THRESHOLD);
+  assert.deepEqual(next, {
+    status: 'degraded', last_success: '2026-04-20T00:00:00Z', consecutive_failures: 1, last_error: 'HTTP 500',
+  });
+});
+
+test('error status → alert when failures reach threshold', () => {
+  const prior = { status: 'degraded', last_success: '2026-04-19T00:00:00Z', consecutive_failures: 2, last_error: 'HTTP 500' };
+  const fc = { status: 'error', error: 'HTTP 500' };
+  const next = updateSourceHealth(prior, fc, NOW, THRESHOLD);
+  assert.equal(next.status, 'alert');
+  assert.equal(next.consecutive_failures, 3);
+});
+
+test('degraded_stale status is treated like error (increments + eventually alerts)', () => {
+  const prior = { status: 'healthy', last_success: '2026-04-20T00:00:00Z', consecutive_failures: 0, last_error: null };
+  const fc = { status: 'degraded_stale', error: 'newest item is 823h old' };
+  const next = updateSourceHealth(prior, fc, NOW, THRESHOLD);
+  assert.equal(next.status, 'degraded');
+  assert.equal(next.consecutive_failures, 1);
+  assert.equal(next.last_error, 'newest item is 823h old');
+});
+
+test('missing prior entry (new source) is treated as healthy baseline', () => {
+  const fc = { status: 'ok', error: null };
+  const next = updateSourceHealth(undefined, fc, NOW, THRESHOLD);
+  assert.deepEqual(next, {
+    status: 'healthy', last_success: NOW, consecutive_failures: 0, last_error: null,
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/health.test.js`
+
+Expected: fails — module doesn't exist.
+
+- [ ] **Step 3: Implement `updateSourceHealth`**
+
+Create `scripts/lib/health.js`:
+
+```js
+function updateSourceHealth(prior, fetchCacheEntry, now, failureThreshold) {
+  const prev = prior || { status: 'healthy', last_success: null, consecutive_failures: 0, last_error: null };
+  const s = fetchCacheEntry.status;
+  if (s === 'ok') {
+    return {
+      status: 'healthy',
+      last_success: now,
+      consecutive_failures: 0,
+      last_error: null,
+    };
+  }
+  // s === 'error' | 'degraded_stale' → accumulate failures
+  const failures = (prev.consecutive_failures || 0) + 1;
+  const status = failures >= failureThreshold ? 'alert' : 'degraded';
+  return {
+    status,
+    last_success: prev.last_success,
+    consecutive_failures: failures,
+    last_error: fetchCacheEntry.error || null,
+  };
+}
+
+module.exports = { updateSourceHealth };
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/lib/health.test.js`
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/health.js scripts/lib/health.test.js
+git commit -m "feat(health): extract health state machine as pure function"
+```
+
+---
+
+## Task 5: `scripts/build-report.js` core — dedup, thread merge, importance filter (TDD)
+
+**Files:**
+- Create: `scripts/build-report.js`
+- Create: `scripts/build-report.test.js`
+
+This task implements the *pure transform* functions (no file I/O, no git, no gh). We cover the I/O orchestration in Task 9.
+
+- [ ] **Step 1: Write failing tests for the transforms**
+
+Create `scripts/build-report.test.js`:
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  filterAlreadyReported,
+  mergeThreads,
+  applyDuplicateOf,
+  filterByImportance,
+  urlHash,
+} = require('./build-report');
+
+test('urlHash: sha256 hex of URL — 64-char, deterministic, differs per URL', () => {
+  assert.match(urlHash('https://example.com/a'), /^[0-9a-f]{64}$/);
+  assert.equal(urlHash('https://example.com/a'), urlHash('https://example.com/a'));
+  assert.notEqual(urlHash('https://example.com/a'), urlHash('https://example.com/b'));
+});
+
+test('filterAlreadyReported: drops articles whose url-hash is in history', () => {
+  const history = { articles: { [urlHash('https://example.com/old')]: { title: 'old' } } };
+  const input = [
+    { url: 'https://example.com/old' },
+    { url: 'https://example.com/new' },
+  ];
+  assert.deepEqual(filterAlreadyReported(input, history).map((a) => a.url),
+    ['https://example.com/new']);
+});
+
+test('mergeThreads: groups articles with same thread_group_id under the earliest', () => {
+  const input = [
+    { url: 'https://x.com/a/1', thread_group_id: 't1', published_at: '2026-04-22T10:02Z', summary: 'B', title: 'second' },
+    { url: 'https://x.com/a/0', thread_group_id: 't1', published_at: '2026-04-22T10:00Z', summary: 'A', title: 'first' },
+    { url: 'https://x.com/a/2', thread_group_id: 't1', published_at: '2026-04-22T10:04Z', summary: 'C', title: 'third' },
+    { url: 'https://x.com/b/0', thread_group_id: null, summary: 'D', title: 'standalone' },
+  ];
+  const out = mergeThreads(input);
+  assert.equal(out.length, 2, 'one thread merged + one standalone');
+  const thread = out.find((a) => a.url === 'https://x.com/a/0');
+  assert.ok(thread, 'canonical is earliest-published article in the thread');
+  assert.match(thread.summary, /A[\s\S]*B[\s\S]*C/, 'summaries concatenated in time order');
+});
+
+test('applyDuplicateOf: canonical gets also_covered_by entries; duplicates dropped', () => {
+  const input = [
+    { url: 'https://anthropic.com/news/x', source: 'Anthropic Blog', duplicate_of: null },
+    { url: 'https://x.com/AnthropicAI/status/1', source: 'Anthropic (Twitter)', duplicate_of: 'https://anthropic.com/news/x' },
+    { url: 'https://deeplearning.ai/the-batch/issue-350', source: 'The Batch', duplicate_of: 'https://anthropic.com/news/x' },
+  ];
+  const out = applyDuplicateOf(input);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].url, 'https://anthropic.com/news/x');
+  assert.deepEqual(out[0].also_covered_by, ['Anthropic (Twitter)', 'The Batch']);
+});
+
+test('filterByImportance: removes articles below threshold', () => {
+  const input = [
+    { url: '1', importance: 5 },
+    { url: '2', importance: 2 },
+    { url: '3', importance: 1 },
+  ];
+  assert.deepEqual(filterByImportance(input, 2).map((a) => a.url), ['1', '2']);
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/build-report.test.js`
+
+Expected: fails — module doesn't exist.
+
+- [ ] **Step 3: Implement the transforms**
+
+Create `scripts/build-report.js`:
+
+```js
+const crypto = require('node:crypto');
+
+function urlHash(url) {
+  return crypto.createHash('sha256').update(url).digest('hex');
+}
+
+function filterAlreadyReported(articles, history) {
+  const known = new Set(Object.keys(history.articles || {}));
+  return articles.filter((a) => !known.has(urlHash(a.url)));
+}
+
+function mergeThreads(articles) {
+  const byId = new Map();
+  const standalone = [];
+  for (const a of articles) {
+    if (!a.thread_group_id) { standalone.push(a); continue; }
+    const group = byId.get(a.thread_group_id) || [];
+    group.push(a);
+    byId.set(a.thread_group_id, group);
+  }
+  const merged = [];
+  for (const group of byId.values()) {
+    group.sort((x, y) => String(x.published_at).localeCompare(String(y.published_at)));
+    const [canonical, ...rest] = group;
+    const summary = [canonical.summary, ...rest.map((r) => r.summary).filter(Boolean)].filter(Boolean).join(' ');
+    merged.push({ ...canonical, summary, extras: { ...(canonical.extras || {}), thread_urls: group.map((g) => g.url) } });
+  }
+  return [...merged, ...standalone];
+}
+
+function applyDuplicateOf(articles) {
+  const byUrl = new Map(articles.map((a) => [a.url, a]));
+  const surviving = [];
+  for (const a of articles) {
+    if (!a.duplicate_of) { surviving.push(a); continue; }
+    const canonical = byUrl.get(a.duplicate_of);
+    if (!canonical) { surviving.push(a); continue; }  // canonical missing: keep the duplicate
+    canonical.also_covered_by = [...(canonical.also_covered_by || []), a.source];
+  }
+  return surviving.filter((a) => !a.duplicate_of || !byUrl.get(a.duplicate_of));
+}
+
+function filterByImportance(articles, minImportance) {
+  return articles.filter((a) => (a.importance || 0) >= minImportance);
+}
+
+module.exports = { urlHash, filterAlreadyReported, mergeThreads, applyDuplicateOf, filterByImportance };
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/build-report.test.js`
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/build-report.js scripts/build-report.test.js
+git commit -m "feat(build-report): pure transforms for dedup, thread merge, filter"
+```
+
+---
+
+## Task 6: History update + retention cleanup (TDD)
+
+**Files:**
+- Modify: `scripts/build-report.js`
+- Modify: `scripts/build-report.test.js`
+
+- [ ] **Step 1: Append failing tests**
+
+Add to `scripts/build-report.test.js`:
+
+```js
+const { appendToHistory, applyRetention } = require('./build-report');
+
+test('appendToHistory: adds entries keyed by url-hash, preserves existing', () => {
+  const history = { articles: { 'existing-hash': { title: 'old' } } };
+  const articles = [
+    { url: 'https://example.com/a', title: 'A', source: 'X', published_at: '2026-04-22', summary: 'sA', category: '研究', importance: 3, tags: ['t'] },
+    { url: 'https://example.com/b', title: 'B', source: 'X', published_at: '2026-04-22', summary: 'sB', category: '研究', importance: 2, tags: [] },
+  ];
+  const fetchedAtISO = '2026-04-22T00:09:08Z';
+  appendToHistory(history, articles, fetchedAtISO);
+  const keys = Object.keys(history.articles);
+  assert.equal(keys.length, 3);
+  const hashA = urlHash('https://example.com/a');
+  assert.equal(history.articles[hashA].title, 'A');
+  assert.equal(history.articles[hashA].fetched_at, fetchedAtISO);
+  assert.equal(history.articles[hashA].extras.tags.length, 1);
+});
+
+test('appendToHistory: stores extras.practice_suggestions when present', () => {
+  const history = { articles: {} };
+  const articles = [
+    { url: '1', title: 't', source: 's', published_at: 'p', summary: 'sx', category: '模型发布', importance: 5, tags: ['a'], practice_suggestions: ['step 1'] },
+  ];
+  appendToHistory(history, articles, '2026-04-22T00:00:00Z');
+  const entry = Object.values(history.articles)[0];
+  assert.deepEqual(entry.extras.practice_suggestions, ['step 1']);
+});
+
+test('applyRetention: removes entries older than cutoff', () => {
+  const history = {
+    articles: {
+      h1: { fetched_at: '2026-01-01T00:00:00Z' },
+      h2: { fetched_at: '2026-04-20T00:00:00Z' },
+      h3: { fetched_at: '2026-04-21T00:00:00Z' },
+    },
+  };
+  const now = new Date('2026-04-22T00:00:00Z');
+  const removed = applyRetention(history, now, 90);
+  assert.equal(removed, 1);
+  assert.deepEqual(Object.keys(history.articles).sort(), ['h2', 'h3']);
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/build-report.test.js`
+
+Expected: 3 new tests fail.
+
+- [ ] **Step 3: Implement `appendToHistory` and `applyRetention`**
+
+Append to `scripts/build-report.js` (before `module.exports`):
+
+```js
+function appendToHistory(history, articles, fetchedAtISO) {
+  for (const a of articles) {
+    const extras = { tags: a.tags || [] };
+    if (a.practice_suggestions?.length) extras.practice_suggestions = a.practice_suggestions;
+    if (a.also_covered_by?.length) extras.also_covered_by = a.also_covered_by;
+    if (a.extras?.thread_urls) extras.thread_urls = a.extras.thread_urls;
+    history.articles[urlHash(a.url)] = {
+      title: a.title,
+      url: a.url,
+      source: a.source,
+      published_at: a.published_at,
+      fetched_at: fetchedAtISO,
+      summary: a.summary,
+      category: a.category,
+      importance: a.importance,
+      extras,
+    };
+  }
+  history.last_fetch = fetchedAtISO;
+}
+
+function applyRetention(history, now, retentionDays) {
+  const cutoff = new Date(now.getTime() - retentionDays * 24 * 3600 * 1000);
+  let removed = 0;
+  for (const [k, v] of Object.entries(history.articles)) {
+    if (v.fetched_at && new Date(v.fetched_at) < cutoff) {
+      delete history.articles[k];
+      removed++;
+    }
+  }
+  return removed;
+}
+```
+
+Update `module.exports`:
+
+```js
+module.exports = {
+  urlHash,
+  filterAlreadyReported, mergeThreads, applyDuplicateOf, filterByImportance,
+  appendToHistory, applyRetention,
+};
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/build-report.test.js`
+
+Expected: 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/build-report.js scripts/build-report.test.js
+git commit -m "feat(build-report): history update + retention cleanup transforms"
+```
+
+---
+
+## Task 7: gh issue alert wrapper (TDD, with shell injection)
+
+**Files:**
+- Modify: `scripts/build-report.js`
+- Modify: `scripts/build-report.test.js`
+
+- [ ] **Step 1: Append failing tests**
+
+Add to `scripts/build-report.test.js`:
+
+```js
+const { manageAlerts } = require('./build-report');
+
+test('manageAlerts: opens new issue when alert source has no existing open issue', async () => {
+  const shellCalls = [];
+  const shell = async (cmd) => {
+    shellCalls.push(cmd);
+    if (cmd.startsWith('gh issue list')) return '[]';  // no existing
+    if (cmd.startsWith('gh issue create')) return 'https://github.com/foo/bar/issues/42';
+    return '';
+  };
+  const health = {
+    'OpenAI Blog': { status: 'alert', consecutive_failures: 3, last_error: 'HTTP 500' },
+    'Google AI Blog': { status: 'healthy', consecutive_failures: 0 },
+  };
+  const prevHealth = { 'OpenAI Blog': { status: 'degraded', consecutive_failures: 2 } };
+  await manageAlerts(health, prevHealth, { shell });
+  assert.ok(shellCalls.some((c) => c.includes('gh issue list')));
+  assert.ok(shellCalls.some((c) => c.startsWith('gh issue create') && c.includes('OpenAI Blog')));
+});
+
+test('manageAlerts: closes issue when previously-alerting source is now healthy', async () => {
+  const shellCalls = [];
+  const shell = async (cmd) => {
+    shellCalls.push(cmd);
+    if (cmd.startsWith('gh issue list')) {
+      return JSON.stringify([{ number: 7, title: 'CatchUp: OpenAI Blog 连续抓取失败' }]);
+    }
+    return '';
+  };
+  const health = { 'OpenAI Blog': { status: 'healthy', consecutive_failures: 0 } };
+  const prevHealth = { 'OpenAI Blog': { status: 'alert', consecutive_failures: 3 } };
+  await manageAlerts(health, prevHealth, { shell });
+  assert.ok(shellCalls.some((c) => c.startsWith('gh issue close 7')));
+});
+
+test('manageAlerts: does nothing for sources that stayed healthy', async () => {
+  const shellCalls = [];
+  const shell = async (cmd) => { shellCalls.push(cmd); return '[]'; };
+  const health = { 'OpenAI Blog': { status: 'healthy', consecutive_failures: 0 } };
+  const prevHealth = { 'OpenAI Blog': { status: 'healthy', consecutive_failures: 0 } };
+  await manageAlerts(health, prevHealth, { shell });
+  assert.equal(shellCalls.length, 0);
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/build-report.test.js`
+
+Expected: 3 new tests fail.
+
+- [ ] **Step 3: Implement `manageAlerts`**
+
+Append to `scripts/build-report.js`:
+
+```js
+const { execSync } = require('node:child_process');
+
+function defaultShell(cmd) {
+  return execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+async function manageAlerts(health, prevHealth, { shell } = {}) {
+  const run = shell || defaultShell;
+  for (const [name, h] of Object.entries(health)) {
+    const prev = prevHealth[name] || { status: 'healthy' };
+    if (h.status === 'alert' && prev.status !== 'alert') {
+      const raw = await run(`gh issue list --label source-alert --state open --json number,title`);
+      const issues = JSON.parse(raw || '[]');
+      const hasOpen = issues.some((i) => i.title.includes(name));
+      if (!hasOpen) {
+        const title = `CatchUp: ${name} 连续抓取失败`;
+        const body = `Source: ${name}\nConsecutive failures: ${h.consecutive_failures}\nLast error: ${h.last_error}`;
+        await run(`gh issue create --title ${JSON.stringify(title)} --label source-alert --body ${JSON.stringify(body)}`);
+      }
+    }
+    if (prev.status === 'alert' && h.status === 'healthy') {
+      const raw = await run(`gh issue list --label source-alert --state open --json number,title`);
+      const issues = JSON.parse(raw || '[]');
+      const match = issues.find((i) => i.title.includes(name));
+      if (match) {
+        await run(`gh issue close ${match.number} --comment "Source recovered and is now healthy."`);
+      }
+    }
+  }
+}
+```
+
+Update `module.exports`:
+
+```js
+module.exports = {
+  urlHash,
+  filterAlreadyReported, mergeThreads, applyDuplicateOf, filterByImportance,
+  appendToHistory, applyRetention,
+  manageAlerts,
+};
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/build-report.test.js`
+
+Expected: 11 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/build-report.js scripts/build-report.test.js
+git commit -m "feat(build-report): gh-issue alert management with shell injection for tests"
+```
+
+---
+
+## Task 8: Main orchestration in `build-report.js`
+
+**Files:**
+- Modify: `scripts/build-report.js`
+
+The orchestration function wires all the pure transforms together and calls the file/shell I/O.
+
+- [ ] **Step 1: Append the `main` orchestration**
+
+Append to `scripts/build-report.js`:
+
+```js
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+const { renderReport } = require('./lib/render-report');
+const { updateSourceHealth } = require('./lib/health');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const FETCH_CACHE_DIR = path.join(PROJECT_ROOT, 'data/fetch-cache');
+const ANALYSIS_CACHE_DIR = path.join(PROJECT_ROOT, 'data/analysis-cache');
+const HISTORY_PATH = path.join(PROJECT_ROOT, 'data/history.json');
+const HEALTH_PATH = path.join(PROJECT_ROOT, 'data/health.json');
+const CONFIG_PATH = path.join(PROJECT_ROOT, 'config.yaml');
+const REPORTS_DIR = path.join(PROJECT_ROOT, 'reports/daily');
+
+function shanghaiDate() {
+  return new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'Asia/Shanghai', year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date());
+}
+
+async function main() {
+  const date = process.env.REPORT_DATE || shanghaiDate();
+  const fetchCachePath = path.join(FETCH_CACHE_DIR, `${date}.json`);
+  const analysisCachePath = path.join(ANALYSIS_CACHE_DIR, `${date}.json`);
+
+  if (!fs.existsSync(fetchCachePath)) {
+    console.error(`fetch-cache missing: ${fetchCachePath}`);
+    process.exit(1);
+  }
+  if (!fs.existsSync(analysisCachePath)) {
+    console.error(`analysis-cache missing: ${analysisCachePath} — routine did not produce one; fallback-report.yml is expected to handle this`);
+    process.exit(0);  // not an error condition for this workflow; the fallback path is what handles it
+  }
+
+  const fetchCache = JSON.parse(fs.readFileSync(fetchCachePath, 'utf8'));
+  const analysisCache = JSON.parse(fs.readFileSync(analysisCachePath, 'utf8'));
+  const history = fs.existsSync(HISTORY_PATH)
+    ? JSON.parse(fs.readFileSync(HISTORY_PATH, 'utf8')) : { articles: {}, last_fetch: null };
+  const healthBefore = fs.existsSync(HEALTH_PATH)
+    ? JSON.parse(fs.readFileSync(HEALTH_PATH, 'utf8')) : {};
+  const config = yaml.load(fs.readFileSync(CONFIG_PATH, 'utf8'));
+
+  const minImportance = config.filtering?.min_importance ?? 2;
+  const retentionDays = config.retention_days || 90;
+  const failureThreshold = config.alerting?.consecutive_failure_threshold || 3;
+
+  // Step 1 — filter out articles already reported (URL-hash dedup)
+  const fresh = filterAlreadyReported(analysisCache.articles, history);
+
+  // Step 2 — thread merge (by thread_group_id)
+  const afterThreads = mergeThreads(fresh);
+
+  // Step 3 — duplicate_of → also_covered_by
+  const canonical = applyDuplicateOf(afterThreads);
+
+  // Step 4 — sort by importance desc, then published_at desc
+  canonical.sort((a, b) =>
+    (b.importance - a.importance) || String(b.published_at).localeCompare(String(a.published_at)));
+
+  // Step 5 — importance filter for the report body
+  const articlesInReport = filterByImportance(canonical, minImportance);
+
+  // Step 6 — render markdown
+  const rawFetched = Object.values(fetchCache.sources).reduce((n, s) => n + (s.articles?.length || 0), 0);
+  const sourcesWithContent = Object.values(fetchCache.sources).filter((s) => (s.articles?.length || 0) > 0).length;
+  const sourceStatuses = Object.entries(fetchCache.sources).map(([name, s]) => ({
+    name,
+    status_note: s.status === 'ok'
+      ? `✅ 正常（窗口内 ${s.articles.length} 文）`
+      : s.status === 'degraded_stale'
+        ? `⚠️ 过期（${s.error}）`
+        : `❌ 错误（${s.error}）`,
+  }));
+  const md = renderReport({
+    date,
+    articlesInReport,
+    rawFetched,
+    mergedCount: canonical.length,
+    sourcesWithContent,
+    filteredLowImportance: canonical.length - articlesInReport.length,
+    trendParagraph: analysisCache.trend_paragraph || '（无趋势段）',
+    sourceStatuses,
+  });
+  fs.mkdirSync(REPORTS_DIR, { recursive: true });
+  fs.writeFileSync(path.join(REPORTS_DIR, `${date}.md`), md);
+
+  // Step 7 — append to history
+  appendToHistory(history, canonical, analysisCache.analyzed_at || fetchCache.fetched_at);
+  const removed = applyRetention(history, new Date(), retentionDays);
+  console.error(`retention cleanup: removed ${removed} entries`);
+  fs.writeFileSync(HISTORY_PATH, JSON.stringify(history, null, 2) + '\n');
+
+  // Step 8 — update health
+  const healthAfter = {};
+  for (const [name, entry] of Object.entries(fetchCache.sources)) {
+    healthAfter[name] = updateSourceHealth(healthBefore[name], entry, fetchCache.fetched_at, failureThreshold);
+  }
+  // carry forward any entries in healthBefore that aren't in today's fetch-cache
+  for (const [name, h] of Object.entries(healthBefore)) {
+    if (!(name in healthAfter)) healthAfter[name] = h;
+  }
+  fs.writeFileSync(HEALTH_PATH, JSON.stringify(healthAfter, null, 2) + '\n');
+
+  // Step 9 — issues
+  await manageAlerts(healthAfter, healthBefore);
+
+  // Step 10 — git add / commit / push
+  const { execSync } = require('node:child_process');
+  const run = (c) => execSync(c, { stdio: 'inherit' });
+  run(`git add data/history.json data/health.json reports/daily/${date}.md`);
+  // If the working tree has no changes (idempotent re-run), skip commit
+  try {
+    execSync('git diff --cached --quiet', { stdio: 'ignore' });
+    console.error('no changes to commit');
+  } catch {
+    run(`git commit -m "chore(catchup): daily report ${date}"`);
+    run('git push');
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => { console.error('fatal:', err); process.exit(2); });
+}
+```
+
+- [ ] **Step 2: Dry-run locally against today's files**
+
+```bash
+source /opt/homebrew/opt/nvm/nvm.sh && REPORT_DATE=2026-04-21 node scripts/build-report.js
+```
+
+Expected behavior:
+- If `data/analysis-cache/2026-04-21.json` does not exist: exits 0 with the "analysis-cache missing" message (correct — fallback handles this).
+- If it exists (we haven't written one yet today; this dry-run will likely exit 0 with the missing message).
+
+Don't commit the transient report file. Reset:
+
+```bash
+git checkout -- data/history.json data/health.json
+rm -f reports/daily/2026-04-21.md  # if anything was produced
+```
+
+- [ ] **Step 3: Verify tests still pass**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/`
+
+Expected: all tests across files pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/build-report.js
+git commit -m "feat(build-report): orchestration entry point — render + history + health + alerts"
+```
+
+---
+
+## Task 9: `.github/workflows/build-report.yml`
+
+**Files:**
+- Create: `.github/workflows/build-report.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/build-report.yml`:
+
+```yaml
+name: Build Report
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/analysis-cache/**'
+  workflow_dispatch:
+    inputs:
+      report_date:
+        description: 'YYYY-MM-DD (Asia/Shanghai). Defaults to today if empty.'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: build-report
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Build report
+        run: node scripts/build-report.js
+        env:
+          REPORT_DATE: ${{ inputs.report_date }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/build-report.yml
+git commit -m "ci: build-report workflow triggered by analysis-cache push"
+```
+
+---
+
+## Task 10: `scripts/fallback-report.js` + tests (TDD)
+
+**Files:**
+- Create: `scripts/fallback-report.js`
+- Create: `scripts/fallback-report.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `scripts/fallback-report.test.js`:
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { renderFallbackReport } = require('./fallback-report');
+
+test('renderFallbackReport: explicit fallback header and per-source article list', () => {
+  const fetchCache = {
+    sources: {
+      'OpenAI Blog': {
+        status: 'ok', articles: [
+          { title: 'Hello', url: 'https://openai.com/index/hello', published_at: '2026-04-22' },
+        ],
+      },
+      'Sam Altman (Twitter)': {
+        status: 'ok', articles: [
+          { title: 'tweet', url: 'https://x.com/sama/status/1', published_at: '2026-04-22' },
+        ],
+      },
+      'Berkeley RDI': { status: 'ok', articles: [] },
+    },
+  };
+  const md = renderFallbackReport('2026-04-22', fetchCache);
+  assert.match(md, /^# CatchUp 日报 — 2026-04-22（fallback/m);
+  assert.match(md, /Claude 分析环节未在预期窗口内产出/);
+  assert.match(md, /## OpenAI Blog/);
+  assert.match(md, /- \[Hello\]\(https:\/\/openai\.com\/index\/hello\)/);
+  assert.match(md, /## Sam Altman \(Twitter\)/);
+  assert.match(md, /- \[tweet\]\(https:\/\/x\.com\/sama\/status\/1\)/);
+  assert.doesNotMatch(md, /## Berkeley RDI/, 'sources with zero articles are omitted');
+});
+
+test('renderFallbackReport: zero-article day still renders with placeholder', () => {
+  const fetchCache = { sources: { 'OpenAI Blog': { status: 'ok', articles: [] } } };
+  const md = renderFallbackReport('2026-04-22', fetchCache);
+  assert.match(md, /今日抓取窗口内全部数据源均无新内容/);
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/fallback-report.test.js`
+
+Expected: fails — module doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+Create `scripts/fallback-report.js`:
+
+```js
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const FETCH_CACHE_DIR = path.join(PROJECT_ROOT, 'data/fetch-cache');
+const REPORTS_DIR = path.join(PROJECT_ROOT, 'reports/daily');
+
+function shanghaiDate() {
+  return new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'Asia/Shanghai', year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date());
+}
+
+function renderFallbackReport(date, fetchCache) {
+  let md = `# CatchUp 日报 — ${date}（fallback，自动回退版）\n\n`;
+  md += '> Claude 分析环节未在预期窗口内产出；以下为仅标题+链接的兜底版本。\n\n---\n\n';
+  const populated = Object.entries(fetchCache.sources).filter(([, s]) => (s.articles?.length || 0) > 0);
+  if (populated.length === 0) {
+    md += '今日抓取窗口内全部数据源均无新内容。\n';
+    return md;
+  }
+  for (const [name, entry] of populated) {
+    md += `## ${name}\n\n`;
+    for (const a of entry.articles) {
+      md += `- [${a.title}](${a.url})\n`;
+    }
+    md += '\n';
+  }
+  return md;
+}
+
+async function main() {
+  const date = process.env.REPORT_DATE || shanghaiDate();
+  const reportPath = path.join(REPORTS_DIR, `${date}.md`);
+  if (fs.existsSync(reportPath)) {
+    console.error(`report already exists at ${reportPath} — fallback not needed`);
+    process.exit(0);
+  }
+  const fetchCachePath = path.join(FETCH_CACHE_DIR, `${date}.json`);
+  if (!fs.existsSync(fetchCachePath)) {
+    console.error(`fetch-cache missing for ${date}; nothing to fall back on`);
+    process.exit(1);
+  }
+  const fetchCache = JSON.parse(fs.readFileSync(fetchCachePath, 'utf8'));
+  const md = renderFallbackReport(date, fetchCache);
+  fs.mkdirSync(REPORTS_DIR, { recursive: true });
+  fs.writeFileSync(reportPath, md);
+
+  const { execSync } = require('node:child_process');
+  execSync(`git add ${reportPath}`, { stdio: 'inherit' });
+  try {
+    execSync('git diff --cached --quiet', { stdio: 'ignore' });
+    console.error('no changes to commit');
+  } catch {
+    execSync(`git commit -m "chore(catchup): fallback daily report ${date}"`, { stdio: 'inherit' });
+    execSync('git push', { stdio: 'inherit' });
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => { console.error('fatal:', err); process.exit(2); });
+}
+
+module.exports = { renderFallbackReport };
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/fallback-report.test.js`
+
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/fallback-report.js scripts/fallback-report.test.js
+git commit -m "feat(fallback-report): guaranteed-delivery minimal report when routine fails"
+```
+
+---
+
+## Task 11: `.github/workflows/fallback-report.yml`
+
+**Files:**
+- Create: `.github/workflows/fallback-report.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/fallback-report.yml`:
+
+```yaml
+name: Fallback Report
+
+on:
+  schedule:
+    - cron: '0 4 * * *'  # 12:00 Asia/Shanghai — 4h 23min after daily-fetch
+  workflow_dispatch:
+    inputs:
+      report_date:
+        description: 'YYYY-MM-DD (Asia/Shanghai). Defaults to today if empty.'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+
+concurrency:
+  group: fallback-report
+  cancel-in-progress: false
+
+jobs:
+  fallback:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run fallback
+        run: node scripts/fallback-report.js
+        env:
+          REPORT_DATE: ${{ inputs.report_date }}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/fallback-report.yml
+git commit -m "ci: fallback-report workflow — daily 12:00 CST safety net"
+```
+
+---
+
+## Task 12: Rewrite `docs/prompts/daily-trigger.md` (slim version)
+
+**Files:**
+- Rewrite: `docs/prompts/daily-trigger.md`
+
+- [ ] **Step 1: Replace the entire file with the slim prompt**
+
+Replace the contents of `docs/prompts/daily-trigger.md` with:
+
+````markdown
+# CatchUp Daily Trigger — Analysis Only
+
+You produce structured analysis of today's AI news into `data/analysis-cache/{date}.json`. You do NOT render the report, update history, update health, or manage GitHub issues — a post-processor handles all that.
+
+Read `CLAUDE.md` first for project context.
+
+## Workflow
+
+### Step 1: Determine today's date
+
+Use Asia/Shanghai timezone, YYYY-MM-DD format. Record as `{date}`.
+
+### Step 2: Load today's fetch-cache
+
+Read `data/fetch-cache/{date}.json`.
+
+**If the file does not exist**: abort immediately. Write one line to stderr (`fetch-cache missing for {date} — aborting`) and exit without committing anything. Do NOT attempt to WebFetch or fabricate content.
+
+### Step 3: Check for resume state
+
+Read `data/analysis-cache/{date}.json` if it exists. It is a partial analysis from an earlier run of this same trigger. Collect the URLs already present in `articles[].url` — call this set `analyzed_urls`.
+
+If the file does not exist, `analyzed_urls` is empty and you will create the file fresh.
+
+### Step 4: Iterate new articles
+
+For each source in `fetch-cache.sources` with `status === "ok"` or `status === "degraded_stale"`:
+- For each article in `articles[]`:
+  - If `article.url` is in `analyzed_urls`: skip.
+  - Else: perform the analysis below.
+
+For each article, determine:
+
+1. **summary** — 2-3 Chinese sentences capturing the key point. Prioritize content sources in this order:
+   - `article.linked_content` (Twitter primary, jina-fetched blog body the tweet points to)
+   - `article.full_text` (blog, jina-fetched body)
+   - `article.quoted_tweet.text + article.description` (when quote-tweet)
+   - `article.description` (fallback)
+2. **category** — one of: `模型发布`, `研究`, `产品与功能`, `商业动态`, `政策与安全`, `教程与观点`
+3. **importance** — integer 1-5. Base score:
+   - **5** NEW MODEL RELEASE (GPT-5, Claude 5, Gemini 3, major open-weight SOTA)
+   - **4** SIGNIFICANT RESEARCH/PRODUCT (paper with empirical result, major product launch, minor version with real capability gain)
+   - **3** NOTABLE UPDATE (feature release, partnership, funding, policy/regulatory, expert deep-dive)
+   - **2** INCREMENTAL (small feature tweak, single observation)
+   - **1** LOW-SIGNAL (greeting, meme, pure RT, reply fragment)
+   Modifier: -1 if source role is `aggregator` AND raw text starts with `RT @` or `@<handle>` (pure retweet/reply).
+4. **tags** — 3-5 Chinese keywords (array).
+5. **practice_suggestions** — 1-3 concrete actionable Chinese suggestions with operating steps, ONLY if `category ∈ {模型发布, 产品与功能}`. Omit the field otherwise.
+6. **thread_group_id** — if this article is one of a self-reply chain of tweets from the same author within 5 minutes covering the same topic, assign them a shared id like `thread-{screen_name}-{YYYYMMDD-HHMM}`. Non-thread articles get `null`.
+7. **duplicate_of** — if this article covers the same topic as another article in today's batch, and that other article is from a `role: primary` source (while this one is aggregator), set `duplicate_of` to the canonical article's URL. Non-duplicates get `null`.
+
+### Step 5: Write incremental progress
+
+**After analyzing each article**:
+- Read the current contents of `data/analysis-cache/{date}.json` (or treat as `{articles: []}` if missing).
+- Append the new article's analysis to `articles[]`.
+- Write the whole file back.
+
+Keeping progress on disk after each article means a crash or timeout does not require re-analyzing everything.
+
+The article JSON shape:
+```json
+{
+  "url": "...",
+  "source": "...",
+  "summary": "...",
+  "category": "...",
+  "importance": 4,
+  "tags": ["..."],
+  "practice_suggestions": ["..."],
+  "thread_group_id": null,
+  "duplicate_of": null
+}
+```
+
+(Omit `practice_suggestions` when not applicable. Use `null` for `thread_group_id` and `duplicate_of` when not set.)
+
+### Step 6: Trend paragraph
+
+Once all articles are analyzed (no unprocessed URLs left), write the whole-batch **trend paragraph** (3-6 Chinese sentences synthesizing the day's themes). Update `data/analysis-cache/{date}.json` to include:
+
+```json
+{
+  "analyzed_at": "{ISO 8601 timestamp, Asia/Shanghai}",
+  "fetch_cache_ref": "data/fetch-cache/{date}.json",
+  "trend_paragraph": "...",
+  "articles": [ ... all articles analyzed above ... ]
+}
+```
+
+If the trigger is re-run and the file already has a `trend_paragraph` but new articles were added, regenerate the trend paragraph to reflect the full current batch.
+
+### Step 7: Commit and push
+
+```bash
+git add data/analysis-cache/{date}.json
+git commit -m "chore(catchup): daily analysis {date}"
+git push
+```
+
+If the file was unchanged (no new articles to add, e.g., resume after full batch was already done), skip the commit.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/prompts/daily-trigger.md
+git commit -m "docs(prompt): slim daily-trigger — analysis-cache output only, no report rendering"
+```
+
+- [ ] **Step 3: Sync the new prompt to the live Cloud Trigger**
+
+This is a manual step — invoke the existing sync skill from an interactive Claude Code session (not inside this plan's execution). The maintainer runs:
+
+```
+/sync-daily-trigger
+```
+
+which calls the `.claude/skills/sync-daily-trigger/` procedure via `RemoteTrigger` API. The skill already handles:
+- listing triggers to find "LLM-CatchUp Daily Report"
+- reading `docs/prompts/daily-trigger.md` content
+- pushing to the trigger via `RemoteTrigger action: "update"`
+- verifying the echo
+
+No code change here. Document in the PR body that the maintainer must run `/sync-daily-trigger` before the next scheduled run.
+
+---
+
+## Task 13: Update `.claude/skills/sync-daily-trigger/SKILL.md`
+
+**Files:**
+- Modify: `.claude/skills/sync-daily-trigger/SKILL.md`
+
+- [ ] **Step 1: Add a note about the new prompt shape**
+
+In the "Why this skill exists" section of `.claude/skills/sync-daily-trigger/SKILL.md`, append a paragraph:
+
+```markdown
+**Prompt shape (as of 2026-04-22):** the daily prompt is now "analysis-only" — it produces `data/analysis-cache/{date}.json` and exits. A separate GH Actions workflow (`build-report.yml`) renders the final markdown report and updates history/health. If you're reading the prompt and it looks much shorter than the weekly/monthly ones, that's intentional — don't restore the removed steps.
+```
+
+(Location: right after the bullet list explaining that triggers hold their own embedded copy.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/sync-daily-trigger/SKILL.md
+git commit -m "docs(skill): note that daily-trigger prompt is analysis-only now"
+```
+
+---
+
+## Task 14: Update `CLAUDE.md` to reflect the new pipeline
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Rewrite the "How It Works" section**
+
+In `CLAUDE.md`, replace the two paragraphs under "## How It Works" with:
+
+```markdown
+This repo has three runtime stages, in order:
+
+**Stage 1 — Fetcher** (`.github/workflows/daily-fetch.yml`, cron `37 23 * * *` UTC = 07:37 Asia/Shanghai). `scripts/fetch-sources.js` reads `config.yaml`, fetches each source via route modules under `scripts/routes/`, filters to a 30h window, enriches blog sources via Jina Reader (`scripts/lib/enrich.js`) and extracts full_text/linked_content where possible, and writes the snapshot to `data/fetch-cache/{YYYY-MM-DD}.json`.
+
+**Stage 2 — Analyzer** (Claude Code Cloud Scheduled Trigger, runs shortly after fetch). The trigger reads `data/fetch-cache/{date}.json` and writes per-article `{summary, category, importance, tags, practice_suggestions, thread_group_id, duplicate_of}` plus a whole-batch `trend_paragraph` to `data/analysis-cache/{date}.json`. Incrementally persisted per article — partial work survives interruptions. Commits and pushes that single file. Does NOT render the markdown report, touch history/health, or manage issues. Prompt: `docs/prompts/daily-trigger.md`; synced to the live trigger via `.claude/skills/sync-daily-trigger/`.
+
+**Stage 3 — Reporter** (`.github/workflows/build-report.yml`, triggered on push to `data/analysis-cache/**`). `scripts/build-report.js` reads fetch-cache + analysis-cache + history + health + config, does URL-hash dedup against history, merges threads, applies `duplicate_of`, renders the markdown report via `scripts/lib/render-report.js`, updates `data/history.json` + `data/health.json`, opens/closes GitHub issues for alerts, and commits+pushes the report + state files.
+
+**Safety net — Fallback** (`.github/workflows/fallback-report.yml`, cron `0 4 * * *` UTC = 12:00 CST). `scripts/fallback-report.js` checks if `reports/daily/{today}.md` exists; if not (Stage 2 or 3 failed), it renders a title+link-only report from fetch-cache alone and commits+pushes. This guarantees the email subscriber always gets something.
+```
+
+- [ ] **Step 2: Remove stale trigger-side rules**
+
+Still in `CLAUDE.md`, under "## Rules for Trigger Agents", the sections "### Analysis", "### Report Generation", "### Health Monitoring", "### Data Cleanup", "### Committing" describe what Claude **used** to do but now are done by `build-report.js` instead. Replace them all with:
+
+```markdown
+## Rules for the Daily Trigger (post-slim)
+
+The daily trigger is now "analysis-only". Its full procedure lives in `docs/prompts/daily-trigger.md`. Summary:
+
+- Read `data/fetch-cache/{date}.json`; abort cleanly if missing (no WebFetch fallback)
+- For each new article, produce `{summary, category, importance, tags, practice_suggestions?, thread_group_id?, duplicate_of?}`
+- Use `linked_content` > `full_text` > `quoted_tweet.text + description` > `description` as summary basis
+- Detect thread groups (self-reply chain within 5 min) and cross-source duplicates
+- Write trend_paragraph
+- Persist incrementally per article into `data/analysis-cache/{date}.json`
+- Commit that one file only
+
+Deterministic concerns (report rendering, history/health updates, retention, GH issues, commits of reports) are outside the trigger's scope — see `scripts/build-report.js`.
+
+Weekly and monthly triggers are unchanged (they aggregate from `data/history.json` and are less frequent; they'll be revisited if they start breaking).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md for three-stage + fallback pipeline"
+```
+
+---
+
+## Task 15: End-to-end verification & PR
+
+**No file changes.**
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+source /opt/homebrew/opt/nvm/nvm.sh && node --test scripts/
+```
+
+Expected: all tests across enrich, socialdata-twitter, render-report, health, build-report, fallback-report, email-reports pass. Count ~35+ tests green.
+
+- [ ] **Step 2: Dry-run build-report with a synthetic analysis-cache**
+
+Create a minimal analysis-cache for today:
+
+```bash
+DATE=$(TZ=Asia/Shanghai date +%Y-%m-%d)
+mkdir -p data/analysis-cache
+cat > data/analysis-cache/$DATE.json <<EOF
+{
+  "analyzed_at": "${DATE}T08:00:00+08:00",
+  "fetch_cache_ref": "data/fetch-cache/${DATE}.json",
+  "trend_paragraph": "（测试用）今日趋势占位段落。",
+  "articles": []
+}
+EOF
+source /opt/homebrew/opt/nvm/nvm.sh && node scripts/build-report.js
+```
+
+Expected: renders an empty-day report `reports/daily/$DATE.md`, writes history and health (no changes if no new articles), prints `retention cleanup: removed 0 entries`, attempts `git add/commit/push`. The push will fail if your local branch isn't behind origin; that's fine for the dry-run.
+
+- [ ] **Step 3: Clean up dry-run artifacts**
+
+```bash
+git reset HEAD~1 --soft   # if a commit was made
+git checkout -- data/history.json data/health.json
+rm -f data/analysis-cache/$DATE.json reports/daily/$DATE.md
+```
+
+- [ ] **Step 4: Dry-run fallback-report**
+
+```bash
+source /opt/homebrew/opt/nvm/nvm.sh && REPORT_DATE=2026-04-21 node scripts/fallback-report.js
+```
+
+Expected:
+- Since `reports/daily/2026-04-21.md` already exists, prints "report already exists at ... — fallback not needed" and exits 0.
+
+Then force the missing-report branch:
+
+```bash
+mv reports/daily/2026-04-21.md /tmp/_backup.md
+source /opt/homebrew/opt/nvm/nvm.sh && REPORT_DATE=2026-04-21 node scripts/fallback-report.js
+mv /tmp/_backup.md reports/daily/2026-04-21.md
+```
+
+Expected: the second invocation writes a fallback report (you can inspect it before restoring the backup).
+
+- [ ] **Step 5: Check git status**
+
+```bash
+git status
+```
+
+Expected: working tree clean.
+
+- [ ] **Step 6: Open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat: slim daily trigger + build-report + fallback-report" --body "$(cat <<'EOF'
+## Summary
+- Daily Claude Cloud Trigger becomes "analysis-only" — writes only data/analysis-cache/{date}.json with per-article analysis + trend paragraph, commits that one file, exits. Per-article checkpoint means partial work survives interruption.
+- New scripts/build-report.js (GH Actions .github/workflows/build-report.yml, push-triggered): URL-hash dedup vs history, thread merge, duplicate_of → also_covered_by, importance filter, markdown render, history.json / health.json updates, retention cleanup, GH issue alerts, commit+push.
+- New scripts/fallback-report.js (.github/workflows/fallback-report.yml, cron 04:00 UTC = 12:00 CST): if today's report is missing, renders title+link-only digest from fetch-cache and commits — guaranteed email delivery floor.
+- Prompt docs/prompts/daily-trigger.md rewritten to slim version.
+- CLAUDE.md + sync-daily-trigger/SKILL.md updated to describe the three-stage + fallback pipeline.
+- Spec: docs/superpowers/specs/2026-04-22-enrichment-and-routine-slim-design.md (Phase 2)
+- Depends on PR 1 (enrichment).
+
+## Post-merge action required
+Run `/sync-daily-trigger` from an interactive Claude Code session to push the new prompt to the live Cloud Scheduled Trigger. Without this, the old 11-step prompt is still running and the analysis-cache flow is inactive.
+
+## Test plan
+- [x] node --test scripts/ — all tests pass
+- [x] Dry-run build-report.js with synthetic analysis-cache → renders report
+- [x] Dry-run fallback-report.js: existing report → noop; missing → renders fallback
+- [ ] After merge + /sync-daily-trigger: observe the next daily run produces analysis-cache; build-report workflow fires on the push; report lands in email
+- [ ] Observe at least one day where routine dies; fallback fires at 12:00 CST; fallback report emailed
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review checklist (for writer)
+
+**Spec § coverage:**
+- § 4.2 target flow (3 stages + fallback) → Tasks 1, 9, 11, 14 ✓
+- § 6.1 prompt reduction table → Task 12 ✓
+- § 6.2 analysis-cache schema → Task 12 ✓
+- § 6.3 per-article checkpoint → Task 12 Step 5 ✓
+- § 6.4 build-report.js → Tasks 5–9 ✓
+- § 6.5 fallback-report.js → Tasks 10, 11 ✓
+- § 6.6 workflow + file list → Tasks 9, 11, 13, 14 ✓
+- § 7 testing → every transform has a test ✓
+- § 8 rollout (PR 2 separate from PR 1, sync-daily-trigger manual step) → Task 12 Step 3 + PR body ✓
+
+**Placeholder scan:** every code step includes the actual code.
+
+**Identifier consistency:** `filterAlreadyReported`, `mergeThreads`, `applyDuplicateOf`, `filterByImportance`, `appendToHistory`, `applyRetention`, `manageAlerts`, `renderArticleBlock`, `renderReport`, `updateSourceHealth`, `renderFallbackReport`, `urlHash` are used consistently across tasks.

--- a/docs/superpowers/specs/2026-04-22-enrichment-and-routine-slim-design.md
+++ b/docs/superpowers/specs/2026-04-22-enrichment-and-routine-slim-design.md
@@ -8,7 +8,10 @@
 
 CatchUp has two concurrent reliability issues:
 
-**Issue A — Low-quality input for blog sources.** The fetcher captures only `{title, url, published_at, description}`. For Twitter the tweet IS the content, so `description` is fine. For RSS/web-scraped blog sources (OpenAI Blog, Google AI Blog, Anthropic Blog, Anthropic Research, The Batch), `description` is the RSS summary — usually one to two sentences, often near-identical to the title. Claude's daily "summary" is therefore a paraphrase of an already-terse summary, not of the actual article body. This shows up in reports as shallow blog summaries compared to rich tweet summaries.
+**Issue A — Low-quality input for blog AND Twitter sources.** The fetcher captures only `{title, url, published_at, description}`. Two different gaps:
+
+- *Blog sources* (OpenAI Blog, Google AI Blog, Anthropic Blog, Anthropic Research, The Batch): `description` is the RSS summary — usually one to two sentences, often near-identical to the title. Claude's "summary" is a paraphrase of an already-terse summary, not of the actual article body.
+- *Twitter sources*: `description` is the tweet's `full_text`, which is complete for standalone tweets but strips the **richer context** that socialdata.tools actually returns: `entities.urls[].expanded_url` (t.co → real URL), `quoted_status` (the tweet being quote-tweeted), `in_reply_to_*` fields (reply/thread context), media entities. For primary-source accounts like @AnthropicAI / @OpenAI / @claudeai, most high-signal tweets are announcement pointers — "Read more: https://t.co/xyz" — where **the linked blog IS the content**, not the tweet text. We currently have no way to follow t.co because we don't preserve the expanded URL. Evidence in today's fetch: the Qwen3.6-Max-Preview tweet's `title` was literally truncated mid-word at "instruction followi" because the raw text ends with "Blog: https://t.co/6hDQJhmkjM" — a pointer to a blog we never resolve.
 
 **Issue B — Daily routine keeps hanging.** The Claude Cloud Scheduled Trigger runs a ~220-line prompt spanning 11 sequential steps (load config/state/cache → semantic dedup → per-article analysis → render markdown → update history → retention cleanup → update health → handle gh-issue alerts → commit → push). The routine's failure rate has been high enough that 2026-04-20 and 2026-04-22 produced no daily report, and 2026-04-21 had to be generated manually. The fetcher side (GH Actions) and email side are rock solid; the single Claude run is the only unreliable link.
 
@@ -133,94 +136,175 @@ Blast radius per failure:
 
 ### 5.1 Scope
 
-Enrich the 5 blog-type sources:
+Enrichment has two distinct paths — **blog enrichment** fetches external article bodies via Jina; **Twitter enrichment** operates on both the raw socialdata response (route-level preservation) and selectively follows linked blog announcements (Jina).
+
+**Blog enrichment (via Jina):**
 
 | Source | Current `description` | Enrich? |
 |---|---|---|
-| OpenAI Blog | RSS summary (1-2 sent.) | ✅ |
-| Google AI Blog | RSS summary (1-2 sent.) | ✅ |
-| Anthropic Blog | listing snippet | ✅ |
-| Anthropic Research | listing snippet | ✅ |
-| The Batch | listing snippet | ✅ |
+| OpenAI Blog | RSS summary (1-2 sent.) | ✅ jina → `full_text` |
+| Google AI Blog | RSS summary (1-2 sent.) | ✅ jina → `full_text` |
+| Anthropic Blog | listing snippet | ✅ jina → `full_text` |
+| Anthropic Research | listing snippet | ✅ jina → `full_text` |
+| The Batch | listing snippet | ✅ jina → `full_text` |
 | Berkeley RDI | **already full text** via existing jina route | not in `ENRICH_SOURCES`; its route module `scripts/routes/berkeley-rdi.js` is updated to set `full_text` directly from the jina-fetched markdown (avoid double-fetching through jina). |
 | 宝玉的分享 | RSS `content:encoded` full body | not in `ENRICH_SOURCES`; its route `scripts/routes/baoyu.js` is verified/updated to set `full_text` from `content:encoded` if present. See §10 open question. |
-| 14 Twitter sources | tweet text (== full content) | ❌ |
+
+**Twitter enrichment (two-layer):**
+
+*Layer A — route-level preservation (`scripts/lib/socialdata-twitter.js`):* stop dropping fields that socialdata already returns. Specifically add:
+- `expanded_urls`: array of `{t_co, expanded_url, display_url}` from `t.entities.urls` — enables t.co resolution and the jina-fetch fallback below
+- `quoted_tweet`: `{author, text, url}` extracted from `t.quoted_status` if `t.is_quote_status`, else null
+- `reply_to`: `{screen_name, status_id}` from `t.in_reply_to_*` if present, else null
+- Stop truncating `title` at 200 chars — use the full text, or drop the `title` field entirely since `description == full_text` covers it
+
+*Layer B — linked-content enrichment (shared with blog enrichment via `scripts/lib/enrich.js`):* for tweets from **primary** sources (config `role: primary`), scan `expanded_urls` for URLs pointing to known primary-source blog domains (`anthropic.com/news/*`, `anthropic.com/research/*`, `openai.com/index/*`, `openai.com/research/*`, `blog.google/*`, `deepmind.google/*`, `deeplearning.ai/the-batch/*`) and `github.com/*` announcement repos. For matching URLs, fetch the target via jina and store as `linked_content`. This captures the actual announcement content behind "Read more: https://t.co/..." tweets.
+
+For aggregator Twitter sources (personal accounts like @sama, @karpathy), skip Layer B — their linked content is high-variance and less likely to be primary announcements; the risk of fetching noise outweighs the benefit.
 
 ### 5.2 Where enrichment lives
 
-**Decision: post-processing phase inside `scripts/fetch-sources.js`**, not inside individual route modules, not a separate script.
+**Layer A — route-level (Twitter only)**: modify `scripts/lib/socialdata-twitter.js` directly to preserve fields that already come back in the API response. No new external fetch. Zero new dependencies.
 
-Rationale:
+**Layer B — post-processing phase inside `scripts/fetch-sources.js`**, not inside individual route modules, not a separate script. Called right after the main per-source fetch loop, before writing the JSON file.
+
+Rationale for Layer B placement:
 - **Single GH Actions job, single commit** — fetch-cache is always fully enriched when it lands on disk.
 - **Route modules stay focused** — they answer "what articles exist in the 30h window", they don't need to know about enrichment policy.
-- **Enrichment logic cross-cuts** — per-host selectors/quirks live in one place.
+- **Enrichment logic cross-cuts** — per-host allowlists for primary blog URLs live in one place.
 
 New file: `scripts/lib/enrich.js`
 
 ```js
 // scripts/lib/enrich.js
-const ENRICH_SOURCES = new Set([
-  'OpenAI Blog',
-  'Google AI Blog',
-  'Anthropic Blog',
-  'Anthropic Research',
-  'The Batch',
+const BLOG_ENRICH_SOURCES = new Set([
+  'OpenAI Blog', 'Google AI Blog', 'Anthropic Blog', 'Anthropic Research', 'The Batch',
 ]);
+
+// For Twitter: which domains are worth following t.co → jina on.
+const PRIMARY_BLOG_URL_PATTERNS = [
+  /^https?:\/\/(www\.)?anthropic\.com\/(news|research)\//,
+  /^https?:\/\/(www\.)?openai\.com\/(index|research|blog)\//,
+  /^https?:\/\/blog\.google\//,
+  /^https?:\/\/(www\.)?deepmind\.google\//,
+  /^https?:\/\/(www\.)?deeplearning\.ai\/the-batch\//,
+];
 
 const JINA_BASE = 'https://r.jina.ai/';
 const TIMEOUT_MS = 20_000;
-const MAX_CHARS = 20_000;  // truncate extremely long pages; protects analysis-cache size
+const MAX_CHARS = 20_000;
 
-async function enrichArticle(article) {
+async function jinaFetch(url) {
   try {
-    const res = await fetchWithTimeout(JINA_BASE + article.url, {
+    const res = await fetchWithTimeout(JINA_BASE + url, {
       headers: { 'Accept': 'text/plain' },
     }, TIMEOUT_MS);
     if (!res.ok) return null;
-    const text = await res.text();
-    return text.slice(0, MAX_CHARS);
-  } catch {
-    return null;
-  }
+    return (await res.text()).slice(0, MAX_CHARS);
+  } catch { return null; }
 }
 
-async function enrichSnapshot(snapshot) {
+function isPrimaryBlogUrl(url) {
+  return PRIMARY_BLOG_URL_PATTERNS.some((re) => re.test(url));
+}
+
+async function enrichSnapshot(snapshot, sourceConfigs) {
+  const roleByName = Object.fromEntries(sourceConfigs.map((s) => [s.name, s.role]));
+  const typeByName = Object.fromEntries(sourceConfigs.map((s) => [s.name, s.type]));
+
   for (const [sourceName, entry] of Object.entries(snapshot.sources)) {
-    if (!ENRICH_SOURCES.has(sourceName)) continue;
     if (entry.status !== 'ok' && entry.status !== 'degraded_stale') continue;
+    const role = roleByName[sourceName];
+    const isTwitter = /Twitter/.test(sourceName);  // or detect via type === 'rss' && url host === x.com
+
     for (const article of entry.articles) {
-      article.full_text = await enrichArticle(article);
+      if (BLOG_ENRICH_SOURCES.has(sourceName)) {
+        article.full_text = await jinaFetch(article.url);
+      }
+      if (isTwitter && role === 'primary' && Array.isArray(article.expanded_urls)) {
+        for (const { expanded_url } of article.expanded_urls) {
+          if (isPrimaryBlogUrl(expanded_url)) {
+            article.linked_content = await jinaFetch(expanded_url);
+            break;  // one link is enough; most tweets point to one blog
+          }
+        }
+      }
     }
   }
 }
 
-module.exports = { enrichSnapshot, ENRICH_SOURCES };
+module.exports = { enrichSnapshot, BLOG_ENRICH_SOURCES, PRIMARY_BLOG_URL_PATTERNS };
 ```
 
-Called from `fetch-sources.js` right after the main per-source fetch loop, before writing the JSON file.
+And in `scripts/lib/socialdata-twitter.js`, update the `.map()` to preserve the extra fields:
+
+```js
+const articles = (data.tweets || []).map((t) => {
+  const screen = t.user?.screen_name || handle;
+  const text = (t.full_text || t.text || '').trim();
+  const expandedUrls = (t.entities?.urls || []).map((u) => ({
+    t_co: u.url,
+    expanded_url: u.expanded_url,
+    display_url: u.display_url,
+  }));
+  const quotedTweet = t.is_quote_status && t.quoted_status ? {
+    author: t.quoted_status.user?.screen_name,
+    text: (t.quoted_status.full_text || t.quoted_status.text || '').trim(),
+    url: t.quoted_status.user?.screen_name && t.quoted_status.id_str
+      ? `https://x.com/${t.quoted_status.user.screen_name}/status/${t.quoted_status.id_str}`
+      : null,
+  } : null;
+  const replyTo = t.in_reply_to_status_id_str ? {
+    screen_name: t.in_reply_to_screen_name,
+    status_id: t.in_reply_to_status_id_str,
+  } : null;
+  return {
+    title: text.slice(0, 200),  // kept for backward compatibility with existing history entries
+    url: `https://x.com/${screen}/status/${t.id_str}`,
+    published_at: t.tweet_created_at || null,
+    description: text,
+    expanded_urls: expandedUrls,
+    quoted_tweet: quotedTweet,
+    reply_to: replyTo,
+  };
+});
+```
 
 ### 5.3 fetch-cache schema change (non-breaking)
 
+Blog-source article:
 ```diff
  {
-   "fetched_at": "...",
-   "window_start": "...",
-   "window_hours": 30,
-   "sources": {
-     "OpenAI Blog": {
-       "status": "ok",
-       "articles": [
-         {
-           "title": "...",
-           "url": "...",
-           "published_at": "...",
--          "description": "..."
-+          "description": "...",
-+          "full_text": "..."          // markdown body, null if enrichment failed
-         }
-       ]
-     }
-   }
+   "title": "...",
+   "url": "...",
+   "published_at": "...",
+-  "description": "..."
++  "description": "...",
++  "full_text": "..."               // jina markdown, null if enrichment failed
+ }
+```
+
+Twitter-source article:
+```diff
+ {
+   "title": "...",                   // first 200 chars of description (compat)
+   "url": "...",
+   "published_at": "...",
+-  "description": "..."
++  "description": "...",
++  "expanded_urls": [                // from socialdata entities.urls
++    { "t_co": "https://t.co/xyz", "expanded_url": "https://openai.com/...", "display_url": "openai.com/..." }
++  ],
++  "quoted_tweet": {                 // null if not a quote-tweet
++    "author": "AnthropicAI",
++    "text": "...",
++    "url": "https://x.com/AnthropicAI/status/..."
++  },
++  "reply_to": {                     // null if not a reply
++    "screen_name": "sama",
++    "status_id": "..."
++  },
++  "linked_content": "..."           // present only for primary-role Twitter sources when expanded_urls contains a known primary blog pattern; null otherwise
  }
 ```
 
@@ -230,16 +314,17 @@ Old consumers that ignore unknown fields (every current reader) keep working.
 
 | Failure | Effect | Detection |
 |---|---|---|
-| Jina down | All 5 sources get `full_text: null` | Report quality degrades to today's level; no crash. Can count `null`s in fetch-cache as a health metric later. |
+| Jina down | All enriched sources get `full_text: null` / `linked_content: null` | Report quality degrades to today's level; no crash. Can count `null`s in fetch-cache as a health metric later. |
 | Jina returns partial/garbage | One article has low-quality text | Analysis still works (Claude is robust); noise tolerance. |
-| Individual URL blocked by jina | Single article `full_text: null` | Falls back to `description`. |
-| Jina rate limits | Same as "Jina down" | Not expected at ~10 articles/day (1M tokens/month free tier ≫ our usage). |
+| Individual URL blocked by jina | Single article enrichment field null | Falls back to `description`. |
+| Jina rate limits | Same as "Jina down" | At new expected volume (~10 blog + ~5 primary-Twitter link-follows/day ≈ 15 jina calls/day) still well within 1M tokens/month free tier. |
+| socialdata schema drift (e.g., `entities.urls[].expanded_url` renamed) | Twitter `expanded_urls` become `[]`; linked_content won't fire | Report degrades to today's level; detectable via a per-run log line counting expanded_urls populated. |
 
 ### 5.5 Cost & limits
 
-- Daily volume: ~5–10 blog articles/day × ~5KB/article = ~50KB/day pulled from Jina.
+- Daily volume: ~5–10 blog articles + ~3–7 primary-Twitter link-follows = ~10–17 jina calls/day × ~5KB each = ~85KB/day pulled from Jina.
 - Jina free tier: **1M tokens/month** (their metering unit) ≈ hundreds of articles. We are well under.
-- Added fetch time: ~2–5s per article, serial → +20–50s to daily-fetch (timeout budget 10min, no issue).
+- Added fetch time: ~2–5s per call, serial → +30–90s to daily-fetch (timeout budget 10min, no issue).
 
 ## 6. Phase 2 — Routine slim-down
 
@@ -276,8 +361,8 @@ update history, or manage health — a post-processor handles all that.
 1. Determine today's date (Asia/Shanghai, YYYY-MM-DD).
 2. Read `data/fetch-cache/{date}.json`. If missing, abort (one-line stderr, no commit).
 3. For each new article across all sources with status `ok` or `degraded_stale`:
-   - Determine `summary` (2-3 Chinese sentences, based on `full_text` if present
-     else `description`)
+   - Determine `summary` (2-3 Chinese sentences, prioritizing: `linked_content` (Twitter)
+     > `full_text` (blog) > `quoted_tweet.text` + `description` (Twitter quote) > `description`)
    - Determine `category` (from: 模型发布/研究/产品与功能/商业动态/政策与安全/教程与观点)
    - Determine `importance` (1-5, using the rubric below)
    - Extract `tags` (3-5 Chinese keywords)

--- a/docs/superpowers/specs/2026-04-22-enrichment-and-routine-slim-design.md
+++ b/docs/superpowers/specs/2026-04-22-enrichment-and-routine-slim-design.md
@@ -1,0 +1,465 @@
+# Article Enrichment + Daily Routine Slim-Down — Design
+
+**Date**: 2026-04-22
+**Status**: Draft, pending user review
+**Author**: Claude + Kevin (pair)
+
+## 1. Context & problem
+
+CatchUp has two concurrent reliability issues:
+
+**Issue A — Low-quality input for blog sources.** The fetcher captures only `{title, url, published_at, description}`. For Twitter the tweet IS the content, so `description` is fine. For RSS/web-scraped blog sources (OpenAI Blog, Google AI Blog, Anthropic Blog, Anthropic Research, The Batch), `description` is the RSS summary — usually one to two sentences, often near-identical to the title. Claude's daily "summary" is therefore a paraphrase of an already-terse summary, not of the actual article body. This shows up in reports as shallow blog summaries compared to rich tweet summaries.
+
+**Issue B — Daily routine keeps hanging.** The Claude Cloud Scheduled Trigger runs a ~220-line prompt spanning 11 sequential steps (load config/state/cache → semantic dedup → per-article analysis → render markdown → update history → retention cleanup → update health → handle gh-issue alerts → commit → push). The routine's failure rate has been high enough that 2026-04-20 and 2026-04-22 produced no daily report, and 2026-04-21 had to be generated manually. The fetcher side (GH Actions) and email side are rock solid; the single Claude run is the only unreliable link.
+
+**Empirical evidence (past 7 days):**
+
+| Date | daily-fetch | Claude routine report | email |
+|---|---|---|---|
+| 04-16 | ✅ | ✅ | ✅ |
+| 04-17 | ✅ | ✅ | ✅ |
+| 04-18 | cancelled | ✅ (after re-fetch) | ✅ |
+| 04-19 | ✅ | ✅ | ✅ |
+| 04-20 | ✅ | ✅ (but 0 content) | ❌ Resend testing mode |
+| 04-21 | ✅ | ❌ no report commit | manual |
+| 04-22 | ✅ | ❌ no report commit (pending manual) | — |
+
+Fetch: 7/7. Routine report: 5/7. Email: 4/7 (fixed 04-21).
+
+**Constraint**: No Anthropic API key available. The routine must remain a Cloud Scheduled Trigger; we cannot retire it in favor of SDK-in-CI. Robustness has to come from shrinking the routine's scope and adding deterministic recovery paths around it.
+
+## 2. Goals
+
+- **Improve content quality** — blog summaries based on actual article body, not RSS blurb.
+- **Improve routine reliability** — reduce routine's prompt surface area so hangs are rarer AND less destructive when they do happen.
+- **Preserve analysis quality** — Claude continues to do all judgment work (summary, category, importance, tags, semantic dedup, trend paragraph). Only deterministic mechanics move out of the routine.
+- **Guaranteed daily delivery** — even if the routine fails completely, an email lands in the inbox with at least titles + links (a "fallback report").
+- **Zero new external dependencies for analysis** — no new API keys, no new paid services. Enrichment uses Jina Reader (already a dependency via Berkeley RDI).
+
+## 3. Non-goals (YAGNI)
+
+- Not retiring the Cloud Scheduled Trigger. (Separate track; requires API key.)
+- Not enriching Twitter sources. (Tweet text is already full content.)
+- Not adding JS-rendering or headless browsers. (Jina handles JS for us.)
+- Not solving for >500 enriched articles/month. (Current volume is ~150/month.)
+- Not restructuring history.json's schema. (Append-only growth is fine at current rate.)
+- Not changing how weekly/monthly reports work. (They aggregate from history.json and are less frequent; deal with them if they start breaking.)
+- Not building a web UI / dashboard for the pipeline state.
+
+## 4. Architecture
+
+### 4.1 Current (broken) flow
+
+```
+┌─────────────────────────┐
+│  daily-fetch.yml (GH)   │  07:37 CST
+│  fetch-sources.js       │──→ data/fetch-cache/{YYYY-MM-DD}.json
+└─────────────────────────┘
+
+┌─────────────────────────────────────────┐
+│  Claude Cloud Scheduled Trigger          │  ~08:00 CST
+│  docs/prompts/daily-trigger.md (220 lines│
+│  11 sequential steps, monolithic)       │──→ reports/daily/{YYYY-MM-DD}.md
+│                                          │    history.json updated
+│                                          │    health.json updated
+│                                          │    gh issues opened/closed
+│                                          │    git push
+└─────────────────────────────────────────┘
+
+┌─────────────────────────┐
+│  email-reports.yml (GH) │  on push
+│  email-reports.js       │──→ Resend → inbox
+└─────────────────────────┘
+```
+
+The middle box is the single point of failure.
+
+### 4.2 Target flow
+
+```
+┌─────────────────────────────────────┐
+│  daily-fetch.yml (GH)  07:37 CST    │
+│  scripts/fetch-sources.js           │
+│    - per-source route (same as now) │
+│    - post-fetch: enrich blog items  │──→ data/fetch-cache/{YYYY-MM-DD}.json
+│      via r.jina.ai (new)             │   (now includes full_text per article)
+└─────────────────────────────────────┘
+
+┌─────────────────────────────────────┐
+│  Claude Cloud Scheduled Trigger      │  ~08:00 CST
+│  (slim) ~60 lines, 1 conceptual step │
+│    - read fetch-cache                │──→ data/analysis-cache/{YYYY-MM-DD}.json
+│    - analyze new articles            │  (commit of this file only)
+│    - output structured JSON          │
+│    - append-write per article        │
+│      (checkpoint)                    │
+└─────────────────────────────────────┘
+
+┌─────────────────────────────────────┐
+│  build-report.yml (GH, new)          │  on push to data/analysis-cache/**
+│  scripts/build-report.js             │
+│    - thread merge (URL/time heuristic│
+│    - cross-history dedup (URL hash)  │
+│    - render markdown                 │──→ reports/daily/{YYYY-MM-DD}.md
+│    - update history.json             │    history.json, health.json
+│    - update health.json + alerts     │    gh issues
+│    - retention cleanup               │    git push
+│    - commit+push                     │
+└─────────────────────────────────────┘
+
+┌─────────────────────────────────────┐
+│  fallback-report.yml (GH, new)       │  cron 12:00 CST (≈4h after fetch)
+│  scripts/fallback-report.js          │
+│    - check reports/daily/{today}.md  │
+│    - if missing: read fetch-cache    │──→ reports/daily/{YYYY-MM-DD}.md
+│      and render title+link only      │   (minimal)
+│    - commit+push                     │
+└─────────────────────────────────────┘
+
+┌─────────────────────────┐
+│  email-reports.yml (GH) │  on push to reports/**
+│  (unchanged)            │──→ Resend → inbox
+└─────────────────────────┘
+```
+
+Blast radius per failure:
+- **Fetcher fails** → no articles today (unchanged).
+- **Enrichment fails per article** → that article falls back to `description` (unchanged quality).
+- **Routine fails completely** → fallback-report.yml fires at 12:00 CST, inbox still gets a title/link digest.
+- **Routine fails mid-run** → analysis-cache has partial data; next invocation (manual re-dispatch OR the fallback at 12:00) completes it; build-report.js can run with whatever's there.
+- **build-report.js fails** → fallback path still fires from fetch-cache.
+
+## 5. Phase 1 — Content enrichment (Jina Reader)
+
+### 5.1 Scope
+
+Enrich the 5 blog-type sources:
+
+| Source | Current `description` | Enrich? |
+|---|---|---|
+| OpenAI Blog | RSS summary (1-2 sent.) | ✅ |
+| Google AI Blog | RSS summary (1-2 sent.) | ✅ |
+| Anthropic Blog | listing snippet | ✅ |
+| Anthropic Research | listing snippet | ✅ |
+| The Batch | listing snippet | ✅ |
+| Berkeley RDI | **already full text** via existing jina route | not in `ENRICH_SOURCES`; its route module `scripts/routes/berkeley-rdi.js` is updated to set `full_text` directly from the jina-fetched markdown (avoid double-fetching through jina). |
+| 宝玉的分享 | RSS `content:encoded` full body | not in `ENRICH_SOURCES`; its route `scripts/routes/baoyu.js` is verified/updated to set `full_text` from `content:encoded` if present. See §10 open question. |
+| 14 Twitter sources | tweet text (== full content) | ❌ |
+
+### 5.2 Where enrichment lives
+
+**Decision: post-processing phase inside `scripts/fetch-sources.js`**, not inside individual route modules, not a separate script.
+
+Rationale:
+- **Single GH Actions job, single commit** — fetch-cache is always fully enriched when it lands on disk.
+- **Route modules stay focused** — they answer "what articles exist in the 30h window", they don't need to know about enrichment policy.
+- **Enrichment logic cross-cuts** — per-host selectors/quirks live in one place.
+
+New file: `scripts/lib/enrich.js`
+
+```js
+// scripts/lib/enrich.js
+const ENRICH_SOURCES = new Set([
+  'OpenAI Blog',
+  'Google AI Blog',
+  'Anthropic Blog',
+  'Anthropic Research',
+  'The Batch',
+]);
+
+const JINA_BASE = 'https://r.jina.ai/';
+const TIMEOUT_MS = 20_000;
+const MAX_CHARS = 20_000;  // truncate extremely long pages; protects analysis-cache size
+
+async function enrichArticle(article) {
+  try {
+    const res = await fetchWithTimeout(JINA_BASE + article.url, {
+      headers: { 'Accept': 'text/plain' },
+    }, TIMEOUT_MS);
+    if (!res.ok) return null;
+    const text = await res.text();
+    return text.slice(0, MAX_CHARS);
+  } catch {
+    return null;
+  }
+}
+
+async function enrichSnapshot(snapshot) {
+  for (const [sourceName, entry] of Object.entries(snapshot.sources)) {
+    if (!ENRICH_SOURCES.has(sourceName)) continue;
+    if (entry.status !== 'ok' && entry.status !== 'degraded_stale') continue;
+    for (const article of entry.articles) {
+      article.full_text = await enrichArticle(article);
+    }
+  }
+}
+
+module.exports = { enrichSnapshot, ENRICH_SOURCES };
+```
+
+Called from `fetch-sources.js` right after the main per-source fetch loop, before writing the JSON file.
+
+### 5.3 fetch-cache schema change (non-breaking)
+
+```diff
+ {
+   "fetched_at": "...",
+   "window_start": "...",
+   "window_hours": 30,
+   "sources": {
+     "OpenAI Blog": {
+       "status": "ok",
+       "articles": [
+         {
+           "title": "...",
+           "url": "...",
+           "published_at": "...",
+-          "description": "..."
++          "description": "...",
++          "full_text": "..."          // markdown body, null if enrichment failed
+         }
+       ]
+     }
+   }
+ }
+```
+
+Old consumers that ignore unknown fields (every current reader) keep working.
+
+### 5.4 Failure modes
+
+| Failure | Effect | Detection |
+|---|---|---|
+| Jina down | All 5 sources get `full_text: null` | Report quality degrades to today's level; no crash. Can count `null`s in fetch-cache as a health metric later. |
+| Jina returns partial/garbage | One article has low-quality text | Analysis still works (Claude is robust); noise tolerance. |
+| Individual URL blocked by jina | Single article `full_text: null` | Falls back to `description`. |
+| Jina rate limits | Same as "Jina down" | Not expected at ~10 articles/day (1M tokens/month free tier ≫ our usage). |
+
+### 5.5 Cost & limits
+
+- Daily volume: ~5–10 blog articles/day × ~5KB/article = ~50KB/day pulled from Jina.
+- Jina free tier: **1M tokens/month** (their metering unit) ≈ hundreds of articles. We are well under.
+- Added fetch time: ~2–5s per article, serial → +20–50s to daily-fetch (timeout budget 10min, no issue).
+
+## 6. Phase 2 — Routine slim-down
+
+### 6.1 Prompt reduction
+
+**Today's prompt responsibilities** → **target state**:
+
+| # | Step (today) | Target |
+|---|---|---|
+| 1 | Read config | ⛔ cut (routine gets what it needs from fetch-cache directly) |
+| 2 | Load history.json, health.json | ⛔ cut |
+| 3 | Load fetch-cache | ✅ keep |
+| 3.5 | Semantic dedup (vs history + same-batch) | ✅ keep — Claude outputs `dedup_decisions` |
+| 4 | Per-article analysis | ✅ keep — core of what the routine produces |
+| 5 | Generate markdown report | ⛔ cut (build-report.js) |
+| 6 | Update history.json | ⛔ cut (build-report.js) |
+| 7 | Retention cleanup | ⛔ cut (build-report.js) |
+| 8 | Update health.json | ⛔ cut (build-report.js) |
+| 9 | `gh issue` alerts | ⛔ cut (build-report.js) |
+| 10 | Commit reports/daily + data/history.json + data/health.json + push | 🔄 reduced — commit ONLY `data/analysis-cache/{date}.json` |
+
+**Trend paragraph** is generated by the routine (whole-batch reasoning) as part of the analysis-cache output.
+
+New prompt (target length ~60 lines, 1 conceptual "produce this JSON" task):
+
+```markdown
+# CatchUp Daily Routine — Analysis Only
+
+You produce structured analysis of today's AI news. You do NOT write the report,
+update history, or manage health — a post-processor handles all that.
+
+## Steps
+
+1. Determine today's date (Asia/Shanghai, YYYY-MM-DD).
+2. Read `data/fetch-cache/{date}.json`. If missing, abort (one-line stderr, no commit).
+3. For each new article across all sources with status `ok` or `degraded_stale`:
+   - Determine `summary` (2-3 Chinese sentences, based on `full_text` if present
+     else `description`)
+   - Determine `category` (from: 模型发布/研究/产品与功能/商业动态/政策与安全/教程与观点)
+   - Determine `importance` (1-5, using the rubric below)
+   - Extract `tags` (3-5 Chinese keywords)
+   - If category ∈ {模型发布, 产品与功能}: add `practice_suggestions` (1-3 items)
+4. Identify thread merges: consecutive tweets from the same author within 5 minutes
+   covering the same topic. Output `thread_group_id` shared across them.
+5. Identify cross-source duplicates: Anthropic blog + The Batch + Twitter all
+   covering the same story. Output `duplicate_of` pointing to the canonical entry.
+6. Write one trend paragraph (Chinese, 3-6 sentences) synthesizing the day's themes.
+7. Write `data/analysis-cache/{date}.json` with all the above.
+   IMPORTANT: append each article's analysis immediately as you complete it — do
+   NOT batch until the end. Partial results must survive if you're interrupted.
+8. Commit `data/analysis-cache/{date}.json` and push.
+```
+
+(Importance rubric + anchor examples kept inline — they're short and load-bearing.)
+
+Removed entirely from the prompt: config.yaml reading, history/health management, retention, gh CLI, report rendering, markdown templates.
+
+### 6.2 analysis-cache schema
+
+```json
+{
+  "analyzed_at": "2026-04-22T08:12:00+08:00",
+  "fetch_cache_ref": "data/fetch-cache/2026-04-22.json",
+  "trend_paragraph": "今日...",
+  "articles": [
+    {
+      "url": "https://...",                    // matches fetch-cache article
+      "source": "Anthropic (Twitter)",
+      "summary": "...",
+      "category": "商业动态",
+      "importance": 5,
+      "tags": ["Anthropic", "Amazon", "AWS", "算力基建", "融资"],
+      "practice_suggestions": ["..."],          // omitted unless category ∈ {模型发布, 产品与功能}
+      "thread_group_id": "thread-a1b2c3",       // null or shared id
+      "duplicate_of": null                       // null or url of canonical entry
+    }
+  ]
+}
+```
+
+**URL-hash dedup against history** is done in build-report.js, not in the routine. The routine sees all articles in fetch-cache and analyzes them all; build-report.js filters anything whose URL-hash is already in history.json before writing the report. This is safer than expecting the routine to do URL-hash filtering.
+
+### 6.3 Per-article checkpoint
+
+The routine persists progress incrementally. If the routine is re-triggered (manual dispatch or second scheduled run), it resumes instead of starting over.
+
+**Mechanism**: the prompt instructs Claude, after analyzing each article, to **read the current `analysis-cache/{date}.json`** (if it exists), **append the new article's analysis to the `articles` array**, and **write the whole file back** (whole-file rewrite — simpler and safe since there's one writer at a time and the file is small). On the next run it re-reads the file, sees already-analyzed URLs, and only processes the remaining ones.
+
+The `trend_paragraph` is written only once — on the final article of the batch — and may be overwritten/updated on resumed runs. (Acceptable: the trend is cheap to regenerate and we want it to reflect the final full batch.)
+
+**Consequence**: a stuck routine that wrote 7/12 articles before hanging only needs to re-analyze 5 on retry, not 12. Idempotent by URL.
+
+### 6.4 `scripts/build-report.js` (new, replaces most of the old routine)
+
+Runs in a new workflow `build-report.yml` triggered by push to `data/analysis-cache/**`.
+
+```
+Input:  data/fetch-cache/{date}.json
+        data/analysis-cache/{date}.json
+        data/history.json
+        data/health.json
+        config.yaml
+
+Output: reports/daily/{date}.md    (new file)
+        data/history.json          (appended)
+        data/health.json           (updated)
+        gh issues                  (opened/closed as needed)
+        git commit + push
+```
+
+Deterministic logic:
+1. Load inputs.
+2. For each article in analysis-cache:
+   - Compute SHA-256(url).
+   - If hash in history.json → skip (already reported).
+   - If `duplicate_of` points to another article in this batch → add to canonical's `also_covered_by`, skip as standalone.
+   - Else → include in today's report.
+3. Group by thread_group_id; concat their summaries under the canonical URL (thread merge).
+4. Sort by `importance` desc, `published_at` desc.
+5. Filter: `importance >= config.filtering.min_importance` (default 2) — low-importance items persisted to history, not shown in body.
+6. Render markdown using the template (same format as today, extracted to code).
+7. Append entries to history.json; set `last_fetch`.
+8. Apply retention: delete entries where `fetched_at < now - retention_days`.
+9. Update health.json from fetch-cache source statuses (same logic as today's Step 8).
+10. For sources reaching `consecutive_failures >= threshold`, `gh issue list --label source-alert` and `gh issue create` if missing. For recovered sources, close their open issue.
+11. `git add data/history.json data/health.json reports/daily/{date}.md && git commit && git push`.
+
+All of this is testable in Node; `email-push-design.md` shows we already unit-test email-reports.js similarly.
+
+### 6.5 `scripts/fallback-report.js` (new, guaranteed-delivery floor)
+
+Runs in a new workflow `fallback-report.yml` with cron `0 4 * * *` UTC (12:00 CST — 4.5h after fetch).
+
+Logic:
+1. Compute today's Asia/Shanghai date.
+2. If `reports/daily/{date}.md` already exists → exit 0 (routine succeeded, nothing to do).
+3. Else read `data/fetch-cache/{date}.json`. If missing → exit 1 (fetch also failed; nothing we can do).
+4. Render a minimal markdown report: grouped by source, one `-` per article with `[title](url)`, no summaries, no categories, no importance. Explicit header marks this as a fallback:
+   ```
+   # CatchUp 日报 — {date}（fallback，自动回退版）
+   > Claude 分析环节未在预期窗口内产出；以下为仅标题+链接的兜底版本。
+   ```
+5. Commit to `reports/daily/{date}.md` and push.
+
+The existing `email-reports.yml` then fires on push and delivers.
+
+**Do NOT update history.json** in the fallback path — history is for "fully analyzed articles" only. If the routine eventually catches up later in the day, the normal build-report.js can still process the same date's articles (it just won't overwrite the fallback report — that's OK; the inbox already has something, and history stays clean for the weekly/monthly aggregation).
+
+### 6.6 Workflow files
+
+New files:
+- `.github/workflows/build-report.yml` — triggers on `push: paths: data/analysis-cache/**`
+- `.github/workflows/fallback-report.yml` — cron + manual dispatch
+- `scripts/build-report.js`
+- `scripts/build-report.test.js`
+- `scripts/fallback-report.js`
+- `scripts/fallback-report.test.js`
+
+Modified files:
+- `scripts/fetch-sources.js` — call `enrichSnapshot()`
+- `scripts/lib/enrich.js` — new
+- `docs/prompts/daily-trigger.md` — slim-down rewrite
+- `.claude/skills/sync-daily-trigger/SKILL.md` — unchanged procedure, but note the new prompt shape
+
+Unchanged:
+- `.github/workflows/daily-fetch.yml` (still calls fetch-sources.js; enrichment happens transparently inside)
+- `.github/workflows/email-reports.yml`
+- `scripts/email-reports.js`
+- Route modules under `scripts/routes/**`
+
+## 7. Testing strategy
+
+**Unit tests** (Node, existing `node --test` harness):
+- `enrich.test.js`: mocked jina responses (ok / 403 / timeout / garbage); assert `full_text` set or null correctly; assert Twitter sources untouched.
+- `build-report.test.js`: synthetic fetch-cache + analysis-cache fixtures; assert rendered markdown matches snapshot, history.json correctly updated, dedup-by-hash works, thread merging works, retention cleanup runs, health state machine transitions.
+- `fallback-report.test.js`: fixture with missing report; assert minimal markdown produced; existing-report case is a no-op.
+
+**Integration test** (manual, once):
+- Checkout a commit with enrichment + slim routine + build-report in place.
+- Run `node scripts/fetch-sources.js` locally → inspect fetch-cache for `full_text` fields.
+- Simulate the routine: hand-write a plausible analysis-cache.
+- Run `node scripts/build-report.js` locally → inspect generated report.
+- Trigger the Cloud routine on a test date → observe it produces analysis-cache only.
+
+## 8. Rollout
+
+Ship Phase 1 and Phase 2 as separate PRs, separate days:
+
+**PR 1 — Enrichment (Phase 1, ~1–2h)**
+- `scripts/lib/enrich.js`
+- wire into `fetch-sources.js`
+- schema docs update
+- test with next daily-fetch run (no behavior change for the routine, it just ignores `full_text` at first)
+- observe 2 days to confirm no fetch-time blowups
+
+**PR 2 — Routine slim + build-report + fallback (Phase 2, ~0.5 day)**
+- new scripts + workflows + tests
+- rewrite `docs/prompts/daily-trigger.md`
+- run `.claude/skills/sync-daily-trigger` to push the new prompt to the live trigger
+- observe: routine produces analysis-cache only; build-report.yml picks up; fallback fires if routine dies
+- **PR 2 ships with BOTH paths wired up** — fallback is not "last resort", it's a scheduled safety net from day one
+
+**Migration**: no data migration needed. Existing history.json / health.json / fetch-cache shapes are preserved. The first day after PR 2 lands, the old prompt produces a normal report (if it's still synced); after `sync-daily-trigger` runs, the new prompt takes over.
+
+**Rollback**: revert PR 2 + re-sync old prompt via `sync-daily-trigger` ≈ 10 minutes. PR 1 is independently revertible (remove the enrichment call site).
+
+## 9. Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Jina extracts navigation/sidebar noise alongside article body | Medium | Claude tolerates noise in inputs; observed in current Berkeley RDI usage without issue. If problematic for a specific source, add a per-source cleanup in enrich.js. |
+| Jina goes down | Low | `full_text: null` fallback preserves today's behavior. |
+| build-report.js has a deterministic bug that writes wrong reports | Medium | Extensive unit test coverage before ship; fallback still fires on missing reports but not on wrong reports. Accept this risk; unit-test it hard. |
+| Routine write-append-incrementally doesn't work as described in the prompt (Claude batches anyway) | Medium | First failed run will reveal it; can add explicit "you MUST write after each article" framing. Checkpoint is a nice-to-have, not load-bearing — fallback-report is the real safety net. |
+| Cron drift: fallback fires before routine had a chance to finish | Low | 4h buffer is ~5x the routine's typical runtime. If routine consistently finishes later, push the cron. |
+| Two commits racing (routine commits analysis-cache while build-report is running) | Low | `concurrency: group: build-report, cancel-in-progress: false` in the workflow; per-PR commits are rare (one/day). |
+| Fallback report quality is too low to be useful | Low | Explicit "fallback" marking in the email lets the user know to re-trigger the routine; titles + links are already more useful than silence. |
+
+## 10. Open questions
+
+- **Should we attempt to re-trigger the Claude routine automatically when fallback fires?** The `RemoteTrigger` API can dispatch the daily trigger. Adding this would let the system "self-heal" without manual intervention. Deferred — enough robustness without it; revisit after 2 weeks of observation.
+- **Should enrichment also capture article images / OG previews?** Not now. Adds schema complexity and parsing risk without obvious report-quality payoff.
+- **Should 宝玉的分享 get enrichment via jina?** Its RSS `content:encoded` is usually already full-body. Decision rule during PR 1 implementation: inspect `scripts/routes/baoyu.js`; if it already exposes the full body into `description`, copy it to `full_text` in the route itself; if not, add `宝玉的分享` to `ENRICH_SOURCES`. This is a small branch, not a design question — closed during implementation.

--- a/scripts/fetch-sources.js
+++ b/scripts/fetch-sources.js
@@ -4,6 +4,7 @@ const path = require('node:path');
 const yaml = require('js-yaml');
 
 const routes = require('./routes');
+const { enrichSnapshot } = require('./lib/enrich');
 
 const PROJECT_ROOT = path.resolve(__dirname, '..');
 const CONFIG_PATH = path.join(PROJECT_ROOT, 'config.yaml');
@@ -142,6 +143,10 @@ async function main() {
     };
     anySuccess = true;
   }
+
+  console.error('enriching articles via Jina Reader...');
+  await enrichSnapshot(output, sourceConfigs);
+  console.error('enrichment done');
 
   fs.mkdirSync(CACHE_DIR, { recursive: true });
   const outPath = path.join(CACHE_DIR, `${shanghaiDateStr(fetchedAt)}.json`);

--- a/scripts/lib/enrich.js
+++ b/scripts/lib/enrich.js
@@ -16,6 +16,7 @@ async function jinaFetch(url, { fetchImpl } = {}) {
 
 const BLOG_ENRICH_SOURCES = new Set([
   'OpenAI Blog', 'Google AI Blog', 'Anthropic Blog', 'Anthropic Research', 'The Batch',
+  '宝玉的分享',
 ]);
 
 const PRIMARY_BLOG_URL_PATTERNS = [

--- a/scripts/lib/enrich.js
+++ b/scripts/lib/enrich.js
@@ -1,0 +1,17 @@
+const { fetchText } = require('./http');
+
+const JINA_BASE = 'https://r.jina.ai/';
+const MAX_CHARS = 20_000;
+
+async function jinaFetch(url, { fetchImpl } = {}) {
+  const impl = fetchImpl || ((u) => fetchText(u, { headers: { Accept: 'text/plain' } }));
+  try {
+    const text = await impl(JINA_BASE + url);
+    if (typeof text !== 'string') return null;
+    return text.slice(0, MAX_CHARS);
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { jinaFetch, JINA_BASE, MAX_CHARS };

--- a/scripts/lib/enrich.js
+++ b/scripts/lib/enrich.js
@@ -18,14 +18,46 @@ const BLOG_ENRICH_SOURCES = new Set([
   'OpenAI Blog', 'Google AI Blog', 'Anthropic Blog', 'Anthropic Research', 'The Batch',
 ]);
 
+const PRIMARY_BLOG_URL_PATTERNS = [
+  /^https?:\/\/(www\.)?anthropic\.com\/(news|research)\//,
+  /^https?:\/\/(www\.)?openai\.com\/(index|research|blog)\//,
+  /^https?:\/\/blog\.google\//,
+  /^https?:\/\/(www\.)?deepmind\.google\//,
+  /^https?:\/\/(www\.)?deeplearning\.ai\/the-batch\//,
+];
+
+function isPrimaryBlogUrl(url) {
+  return typeof url === 'string' && PRIMARY_BLOG_URL_PATTERNS.some((re) => re.test(url));
+}
+
 async function enrichSnapshot(snapshot, sourceConfigs, { fetchImpl } = {}) {
+  const roleByName = Object.fromEntries((sourceConfigs || []).map((s) => [s.name, s.role]));
   for (const [sourceName, entry] of Object.entries(snapshot.sources)) {
     if (entry.status !== 'ok' && entry.status !== 'degraded_stale') continue;
-    if (!BLOG_ENRICH_SOURCES.has(sourceName)) continue;
+
+    const isBlog = BLOG_ENRICH_SOURCES.has(sourceName);
+    const isTwitterPrimary = /\(Twitter\)$/.test(sourceName) && roleByName[sourceName] === 'primary';
+    if (!isBlog && !isTwitterPrimary) continue;
+
     for (const article of entry.articles) {
-      article.full_text = await jinaFetch(article.url, { fetchImpl });
+      if (isBlog) {
+        article.full_text = await jinaFetch(article.url, { fetchImpl });
+      }
+      if (isTwitterPrimary) {
+        article.linked_content = null;
+        for (const { expanded_url } of (article.expanded_urls || [])) {
+          if (isPrimaryBlogUrl(expanded_url)) {
+            article.linked_content = await jinaFetch(expanded_url, { fetchImpl });
+            break;
+          }
+        }
+      }
     }
   }
 }
 
-module.exports = { jinaFetch, enrichSnapshot, BLOG_ENRICH_SOURCES, JINA_BASE, MAX_CHARS };
+module.exports = {
+  jinaFetch, enrichSnapshot,
+  BLOG_ENRICH_SOURCES, PRIMARY_BLOG_URL_PATTERNS,
+  JINA_BASE, MAX_CHARS,
+};

--- a/scripts/lib/enrich.js
+++ b/scripts/lib/enrich.js
@@ -14,4 +14,18 @@ async function jinaFetch(url, { fetchImpl } = {}) {
   }
 }
 
-module.exports = { jinaFetch, JINA_BASE, MAX_CHARS };
+const BLOG_ENRICH_SOURCES = new Set([
+  'OpenAI Blog', 'Google AI Blog', 'Anthropic Blog', 'Anthropic Research', 'The Batch',
+]);
+
+async function enrichSnapshot(snapshot, sourceConfigs, { fetchImpl } = {}) {
+  for (const [sourceName, entry] of Object.entries(snapshot.sources)) {
+    if (entry.status !== 'ok' && entry.status !== 'degraded_stale') continue;
+    if (!BLOG_ENRICH_SOURCES.has(sourceName)) continue;
+    for (const article of entry.articles) {
+      article.full_text = await jinaFetch(article.url, { fetchImpl });
+    }
+  }
+}
+
+module.exports = { jinaFetch, enrichSnapshot, BLOG_ENRICH_SOURCES, JINA_BASE, MAX_CHARS };

--- a/scripts/lib/enrich.test.js
+++ b/scripts/lib/enrich.test.js
@@ -86,9 +86,9 @@ test('enrichSnapshot: source with status error is skipped (no fetch, no full_tex
   assert.equal(called, false);
 });
 
-test('BLOG_ENRICH_SOURCES: exactly the five blog sources in the spec', () => {
+test('BLOG_ENRICH_SOURCES: blog-type sources including 宝玉的分享', () => {
   assert.deepEqual([...BLOG_ENRICH_SOURCES].sort(), [
-    'Anthropic Blog', 'Anthropic Research', 'Google AI Blog', 'OpenAI Blog', 'The Batch',
+    'Anthropic Blog', 'Anthropic Research', 'Google AI Blog', 'OpenAI Blog', 'The Batch', '宝玉的分享',
   ]);
 });
 

--- a/scripts/lib/enrich.test.js
+++ b/scripts/lib/enrich.test.js
@@ -1,6 +1,29 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const { jinaFetch } = require('./enrich');
+const { enrichSnapshot, BLOG_ENRICH_SOURCES } = require('./enrich');
+
+function makeSnapshot(extra = {}) {
+  return {
+    sources: {
+      'OpenAI Blog': {
+        status: 'ok',
+        articles: [
+          { title: 'hello', url: 'https://openai.com/index/hello',
+            published_at: '2026-04-22', description: 'short' },
+        ],
+      },
+      'Sam Altman (Twitter)': {
+        status: 'ok',
+        articles: [
+          { title: 'tweet', url: 'https://x.com/sama/status/1',
+            published_at: '2026-04-22', description: 'tweet text' },
+        ],
+      },
+      ...extra,
+    },
+  };
+}
 
 // The default fetch function goes through the real Jina URL via the project's
 // fetchText helper. For unit tests we inject a stub via the second arg.
@@ -25,4 +48,46 @@ test('jinaFetch: returns null on timeout', async () => {
   const fetchStub = async () => { throw new Error('timeout after 20s'); };
   const out = await jinaFetch('https://openai.com/index/foo', { fetchImpl: fetchStub });
   assert.equal(out, null);
+});
+
+test('enrichSnapshot: blog source gets full_text, Twitter source untouched', async () => {
+  const snapshot = makeSnapshot();
+  const calls = [];
+  const fetchImpl = async (u) => { calls.push(u); return 'ENRICHED BODY'; };
+  await enrichSnapshot(snapshot, /* sourceConfigs */ [
+    { name: 'OpenAI Blog', role: 'primary' },
+    { name: 'Sam Altman (Twitter)', role: 'aggregator' },
+  ], { fetchImpl });
+  assert.equal(snapshot.sources['OpenAI Blog'].articles[0].full_text, 'ENRICHED BODY');
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].includes('/openai.com/index/hello'));
+  assert.equal('full_text' in snapshot.sources['Sam Altman (Twitter)'].articles[0], false);
+});
+
+test('enrichSnapshot: blog fetch failure → full_text null (no throw)', async () => {
+  const snapshot = makeSnapshot();
+  const fetchImpl = async () => { throw new Error('HTTP 403'); };
+  await enrichSnapshot(snapshot, [{ name: 'OpenAI Blog', role: 'primary' }], { fetchImpl });
+  assert.equal(snapshot.sources['OpenAI Blog'].articles[0].full_text, null);
+});
+
+test('enrichSnapshot: source with status error is skipped (no fetch, no full_text)', async () => {
+  const snapshot = {
+    sources: {
+      'OpenAI Blog': {
+        status: 'error', error: 'HTTP 500',
+        articles: [],  // real shape has empty articles on error
+      },
+    },
+  };
+  let called = false;
+  const fetchImpl = async () => { called = true; return 'x'; };
+  await enrichSnapshot(snapshot, [{ name: 'OpenAI Blog', role: 'primary' }], { fetchImpl });
+  assert.equal(called, false);
+});
+
+test('BLOG_ENRICH_SOURCES: exactly the five blog sources in the spec', () => {
+  assert.deepEqual([...BLOG_ENRICH_SOURCES].sort(), [
+    'Anthropic Blog', 'Anthropic Research', 'Google AI Blog', 'OpenAI Blog', 'The Batch',
+  ]);
 });

--- a/scripts/lib/enrich.test.js
+++ b/scripts/lib/enrich.test.js
@@ -1,0 +1,28 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { jinaFetch } = require('./enrich');
+
+// The default fetch function goes through the real Jina URL via the project's
+// fetchText helper. For unit tests we inject a stub via the second arg.
+
+test('jinaFetch: returns text on success, truncated to MAX_CHARS', async () => {
+  const big = 'x'.repeat(30_000);
+  const fetchStub = async (url) => {
+    assert.ok(url.startsWith('https://r.jina.ai/'), 'uses jina base');
+    return big;
+  };
+  const out = await jinaFetch('https://openai.com/index/foo', { fetchImpl: fetchStub });
+  assert.equal(out.length, 20_000);
+});
+
+test('jinaFetch: returns null on fetch error (does not throw)', async () => {
+  const fetchStub = async () => { throw new Error('HTTP 403'); };
+  const out = await jinaFetch('https://openai.com/index/foo', { fetchImpl: fetchStub });
+  assert.equal(out, null);
+});
+
+test('jinaFetch: returns null on timeout', async () => {
+  const fetchStub = async () => { throw new Error('timeout after 20s'); };
+  const out = await jinaFetch('https://openai.com/index/foo', { fetchImpl: fetchStub });
+  assert.equal(out, null);
+});

--- a/scripts/lib/enrich.test.js
+++ b/scripts/lib/enrich.test.js
@@ -91,3 +91,108 @@ test('BLOG_ENRICH_SOURCES: exactly the five blog sources in the spec', () => {
     'Anthropic Blog', 'Anthropic Research', 'Google AI Blog', 'OpenAI Blog', 'The Batch',
   ]);
 });
+
+const { PRIMARY_BLOG_URL_PATTERNS } = require('./enrich');
+
+function makeTwitterSnapshot({ role, expandedUrls }) {
+  return {
+    sources: {
+      'Claude (Twitter)': {
+        status: 'ok',
+        articles: [
+          {
+            title: 'announcement',
+            url: 'https://x.com/claudeai/status/1',
+            published_at: '2026-04-22',
+            description: 'Read more: https://t.co/abc',
+            expanded_urls: expandedUrls,
+            quoted_tweet: null,
+            reply_to: null,
+          },
+        ],
+      },
+    },
+    _role: role,  // test-only convenience
+  };
+}
+
+test('enrichSnapshot: primary Twitter + matching primary blog URL → linked_content fetched', async () => {
+  const snapshot = makeTwitterSnapshot({
+    role: 'primary',
+    expandedUrls: [{ t_co: 'https://t.co/abc',
+      expanded_url: 'https://www.anthropic.com/news/cowork-live-artifacts',
+      display_url: 'anthropic.com/news/…' }],
+  });
+  const calls = [];
+  const fetchImpl = async (u) => { calls.push(u); return 'BLOG BODY'; };
+  await enrichSnapshot(snapshot,
+    [{ name: 'Claude (Twitter)', role: 'primary' }],
+    { fetchImpl });
+  assert.equal(snapshot.sources['Claude (Twitter)'].articles[0].linked_content, 'BLOG BODY');
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].includes('www.anthropic.com/news/cowork-live-artifacts'));
+});
+
+test('enrichSnapshot: aggregator Twitter is never enriched', async () => {
+  const snapshot = makeTwitterSnapshot({
+    role: 'aggregator',
+    expandedUrls: [{ t_co: 'https://t.co/abc',
+      expanded_url: 'https://www.anthropic.com/news/foo',
+      display_url: 'anthropic.com/news/…' }],
+  });
+  let called = false;
+  const fetchImpl = async () => { called = true; return 'x'; };
+  await enrichSnapshot(snapshot,
+    [{ name: 'Claude (Twitter)', role: 'aggregator' }],
+    { fetchImpl });
+  assert.equal(called, false);
+  assert.equal('linked_content' in snapshot.sources['Claude (Twitter)'].articles[0], false);
+});
+
+test('enrichSnapshot: primary Twitter with no matching URL → linked_content null', async () => {
+  const snapshot = makeTwitterSnapshot({
+    role: 'primary',
+    expandedUrls: [{ t_co: 'https://t.co/abc',
+      expanded_url: 'https://random-blog.example.com/foo',
+      display_url: 'random-blog.example.com/foo' }],
+  });
+  let called = false;
+  const fetchImpl = async () => { called = true; return 'x'; };
+  await enrichSnapshot(snapshot,
+    [{ name: 'Claude (Twitter)', role: 'primary' }],
+    { fetchImpl });
+  assert.equal(called, false);
+  assert.equal(snapshot.sources['Claude (Twitter)'].articles[0].linked_content, null);
+});
+
+test('enrichSnapshot: stops at first matching URL (one jina call per tweet)', async () => {
+  const snapshot = makeTwitterSnapshot({
+    role: 'primary',
+    expandedUrls: [
+      { t_co: 'a', expanded_url: 'https://www.anthropic.com/news/one', display_url: '' },
+      { t_co: 'b', expanded_url: 'https://openai.com/index/two', display_url: '' },
+    ],
+  });
+  const calls = [];
+  const fetchImpl = async (u) => { calls.push(u); return 'x'; };
+  await enrichSnapshot(snapshot,
+    [{ name: 'Claude (Twitter)', role: 'primary' }],
+    { fetchImpl });
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].includes('anthropic.com/news/one'));
+});
+
+test('PRIMARY_BLOG_URL_PATTERNS matches expected hosts', () => {
+  const matchers = PRIMARY_BLOG_URL_PATTERNS;
+  const match = (u) => matchers.some((re) => re.test(u));
+  assert.ok(match('https://www.anthropic.com/news/foo'));
+  assert.ok(match('https://www.anthropic.com/research/bar'));
+  assert.ok(match('https://openai.com/index/x'));
+  assert.ok(match('https://openai.com/research/y'));
+  assert.ok(match('https://openai.com/blog/z'));
+  assert.ok(match('https://blog.google/technology/ai/something/'));
+  assert.ok(match('https://deepmind.google/discover/blog/foo/'));
+  assert.ok(match('https://www.deeplearning.ai/the-batch/issue-350/'));
+  assert.equal(match('https://random.example.com/foo'), false);
+  assert.equal(match('https://twitter.com/AnthropicAI/status/123'), false);
+});

--- a/scripts/lib/rss-route.js
+++ b/scripts/lib/rss-route.js
@@ -1,7 +1,7 @@
 const { fetchText } = require('./http');
 const { parseRss } = require('./xml');
 
-function makeRssRoute({ name, sourceUrl }) {
+function makeRssRoute({ name, sourceUrl, preserveContent = false }) {
   return {
     name,
     sourceType: 'rss',
@@ -12,12 +12,17 @@ function makeRssRoute({ name, sourceUrl }) {
         const feed = await parseRss(xml);
         const articles = (feed.items || []).map((item) => {
           const isoDate = item.isoDate || (item.pubDate ? new Date(item.pubDate).toISOString() : null);
-          return {
+          const article = {
             title: (item.title || '').trim(),
             url: item.link || '',
             published_at: isoDate,
             description: (item.contentSnippet || item.content || item.description || '').trim(),
           };
+          if (preserveContent) {
+            const body = (item['content:encoded'] || item.content || '').trim();
+            article.full_text = body || null;
+          }
+          return article;
         });
         return { articles, error: null };
       } catch (err) {

--- a/scripts/lib/socialdata-twitter.js
+++ b/scripts/lib/socialdata-twitter.js
@@ -2,6 +2,38 @@ const { fetchText } = require('./http');
 
 const BASE = 'https://api.socialdata.tools';
 
+function mapTweetsToArticles(tweets, handleFallback) {
+  return (tweets || []).map((t) => {
+    const screen = t.user?.screen_name || handleFallback;
+    const text = (t.full_text || t.text || '').trim();
+    const expandedUrls = (t.entities?.urls || []).map((u) => ({
+      t_co: u.url,
+      expanded_url: u.expanded_url,
+      display_url: u.display_url,
+    }));
+    const quotedTweet = (t.is_quote_status && t.quoted_status) ? {
+      author: t.quoted_status.user?.screen_name || null,
+      text: (t.quoted_status.full_text || t.quoted_status.text || '').trim(),
+      url: t.quoted_status.user?.screen_name && t.quoted_status.id_str
+        ? `https://x.com/${t.quoted_status.user.screen_name}/status/${t.quoted_status.id_str}`
+        : null,
+    } : null;
+    const replyTo = t.in_reply_to_status_id_str ? {
+      screen_name: t.in_reply_to_screen_name || null,
+      status_id: t.in_reply_to_status_id_str,
+    } : null;
+    return {
+      title: text.slice(0, 200),
+      url: `https://x.com/${screen}/status/${t.id_str}`,
+      published_at: t.tweet_created_at || null,
+      description: text,
+      expanded_urls: expandedUrls,
+      quoted_tweet: quotedTweet,
+      reply_to: replyTo,
+    };
+  });
+}
+
 function makeTwitterRoute({ name, handle, userId }) {
   if (!handle) throw new Error(`socialdata-twitter: missing handle for ${name}`);
   if (!userId) throw new Error(`socialdata-twitter: missing userId for ${name}`);
@@ -20,16 +52,7 @@ function makeTwitterRoute({ name, handle, userId }) {
           },
         });
         const data = JSON.parse(body);
-        const articles = (data.tweets || []).map((t) => {
-          const screen = t.user?.screen_name || handle;
-          const text = (t.full_text || t.text || '').trim();
-          return {
-            title: text.slice(0, 200),
-            url: `https://x.com/${screen}/status/${t.id_str}`,
-            published_at: t.tweet_created_at || null,
-            description: text,
-          };
-        });
+        const articles = mapTweetsToArticles(data.tweets, handle);
         return { articles, error: null };
       } catch (err) {
         return { articles: [], error: err.message };
@@ -38,4 +61,4 @@ function makeTwitterRoute({ name, handle, userId }) {
   };
 }
 
-module.exports = { makeTwitterRoute };
+module.exports = { makeTwitterRoute, mapTweetsToArticles };

--- a/scripts/lib/socialdata-twitter.test.js
+++ b/scripts/lib/socialdata-twitter.test.js
@@ -1,0 +1,92 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { mapTweetsToArticles } = require('./socialdata-twitter');
+
+// One raw socialdata tweet covering the "announcement + linked blog" pattern.
+const TWEET_WITH_URL_AND_QUOTE = {
+  id_str: '2046227759475921291',
+  full_text: '🚀 Introducing Qwen3.6-Max-Preview\nBlog: https://t.co/6hDQJhmkjM',
+  tweet_created_at: '2026-04-20T14:01:29.000Z',
+  user: { screen_name: 'Alibaba_Qwen' },
+  entities: {
+    urls: [
+      { url: 'https://t.co/6hDQJhmkjM',
+        expanded_url: 'https://qwenlm.github.io/blog/qwen3.6-max/',
+        display_url: 'qwenlm.github.io/blog/qwen3.6-m…' },
+    ],
+    user_mentions: [], hashtags: [], symbols: [],
+  },
+  is_quote_status: true,
+  quoted_status: {
+    id_str: '123456',
+    full_text: 'Scale matters.',
+    user: { screen_name: 'someoneelse' },
+  },
+  in_reply_to_status_id_str: null,
+  in_reply_to_screen_name: null,
+};
+
+const TWEET_PLAIN = {
+  id_str: '111',
+  full_text: 'just a tweet',
+  tweet_created_at: '2026-04-20T12:00:00.000Z',
+  user: { screen_name: 'sama' },
+  entities: { urls: [], user_mentions: [], hashtags: [], symbols: [] },
+  is_quote_status: false,
+  quoted_status: null,
+  in_reply_to_status_id_str: null,
+  in_reply_to_screen_name: null,
+};
+
+const TWEET_REPLY = {
+  id_str: '222',
+  full_text: 'yes exactly',
+  tweet_created_at: '2026-04-20T13:00:00.000Z',
+  user: { screen_name: 'sama' },
+  entities: { urls: [], user_mentions: [], hashtags: [], symbols: [] },
+  is_quote_status: false,
+  quoted_status: null,
+  in_reply_to_status_id_str: '2046000000000000000',
+  in_reply_to_screen_name: 'pg',
+};
+
+test('mapTweetsToArticles: preserves expanded_urls', () => {
+  const [a] = mapTweetsToArticles([TWEET_WITH_URL_AND_QUOTE], 'Alibaba_Qwen');
+  assert.deepEqual(a.expanded_urls, [
+    { t_co: 'https://t.co/6hDQJhmkjM',
+      expanded_url: 'https://qwenlm.github.io/blog/qwen3.6-max/',
+      display_url: 'qwenlm.github.io/blog/qwen3.6-m…' },
+  ]);
+});
+
+test('mapTweetsToArticles: preserves quoted_tweet when is_quote_status', () => {
+  const [a] = mapTweetsToArticles([TWEET_WITH_URL_AND_QUOTE], 'Alibaba_Qwen');
+  assert.deepEqual(a.quoted_tweet, {
+    author: 'someoneelse',
+    text: 'Scale matters.',
+    url: 'https://x.com/someoneelse/status/123456',
+  });
+});
+
+test('mapTweetsToArticles: quoted_tweet is null when not a quote-tweet', () => {
+  const [a] = mapTweetsToArticles([TWEET_PLAIN], 'sama');
+  assert.equal(a.quoted_tweet, null);
+});
+
+test('mapTweetsToArticles: reply_to set when in_reply_to_status_id_str present', () => {
+  const [a] = mapTweetsToArticles([TWEET_REPLY], 'sama');
+  assert.deepEqual(a.reply_to, { screen_name: 'pg', status_id: '2046000000000000000' });
+});
+
+test('mapTweetsToArticles: reply_to is null for non-reply tweets', () => {
+  const [a] = mapTweetsToArticles([TWEET_PLAIN], 'sama');
+  assert.equal(a.reply_to, null);
+});
+
+test('mapTweetsToArticles: existing fields (title, url, description, published_at) unchanged', () => {
+  const [a] = mapTweetsToArticles([TWEET_PLAIN], 'sama');
+  assert.equal(a.title, 'just a tweet');
+  assert.equal(a.url, 'https://x.com/sama/status/111');
+  assert.equal(a.description, 'just a tweet');
+  assert.equal(a.published_at, '2026-04-20T12:00:00.000Z');
+});

--- a/scripts/routes/baoyu.js
+++ b/scripts/routes/baoyu.js
@@ -3,4 +3,5 @@ const { makeRssRoute } = require('../lib/rss-route');
 module.exports = makeRssRoute({
   name: '宝玉的分享',
   sourceUrl: 'https://baoyu.io/feed.xml',
+  preserveContent: true,
 });

--- a/scripts/routes/berkeley-rdi.js
+++ b/scripts/routes/berkeley-rdi.js
@@ -31,6 +31,7 @@ module.exports = {
         url: p.canonical_url || `${CANONICAL_BASE}/p/${p.slug}`,
         published_at: p.post_date || null,
         description: (p.subtitle || p.description || p.truncated_body_text || '').trim().slice(0, 500) || null,
+        full_text: (p.truncated_body_text || p.description || '').trim() || null,
       }));
       return { articles, error: null };
     } catch (err) {


### PR DESCRIPTION
## Summary
- New scripts/lib/enrich.js: jinaFetch + enrichSnapshot
- Blog sources (OpenAI Blog, Google AI Blog, Anthropic Blog, Anthropic Research, The Batch, 宝玉的分享) get full_text via Jina Reader
- Twitter routes preserve expanded_urls, quoted_tweet, reply_to from socialdata response
- Primary Twitter sources follow expanded_urls matching known primary-blog patterns → linked_content
- Berkeley RDI sets full_text from truncated_body_text (no double-fetch through jina)
- 宝玉的分享 is routed through jina (added to BLOG_ENRICH_SOURCES after discovering its RSS lacks content:encoded)
- Spec: docs/superpowers/specs/2026-04-22-enrichment-and-routine-slim-design.md (Phase 1)

## Test plan
- [x] scripts/lib/enrich.test.js passes (12 tests)
- [x] scripts/lib/socialdata-twitter.test.js passes (6 tests)
- [x] Local fetch-sources.js run produces enriched fetch-cache with expected fields
- [ ] First daily-fetch GH Actions run after merge shows enriched fetch-cache on origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)