### PR TITLE
feat: slim daily trigger + build-report + fallback-report

### DIFF
--- a/.claude/skills/sync-daily-trigger/SKILL.md
+++ b/.claude/skills/sync-daily-trigger/SKILL.md
@@ -12,6 +12,8 @@ Pushes the current `docs/prompts/daily-trigger.md` content to the live CatchUp d
 
 The cloud scheduled trigger holds its own copy of the prompt, baked in at trigger-create time. Editing the repo file keeps `CLAUDE.md`'s claim that `docs/prompts/` is "source of truth" honest, but **the running trigger doesn't re-read from git** — it uses the embedded copy. The weekly and monthly triggers have the same property (separate skill if you need those too).
 
+**Prompt shape (as of 2026-04-22):** the daily prompt is now "analysis-only" — it produces `data/analysis-cache/{date}.json` and exits. A separate GH Actions workflow (`build-report.yml`) renders the final markdown report and updates history/health. If you're reading the prompt and it looks much shorter than the weekly/monthly ones, that's intentional — don't restore the removed steps.
+
 ## Procedure
 
 ### 1. List triggers to find the daily one

--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -1,0 +1,57 @@
+name: Build Report
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/analysis-cache/**'
+  workflow_dispatch:
+    inputs:
+      report_date:
+        description: 'YYYY-MM-DD (Asia/Shanghai). Defaults to today if empty.'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: build-report
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Build report
+        run: node scripts/build-report.js
+        env:
+          REPORT_DATE: ${{ inputs.report_date }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fallback-report.yml
+++ b/.github/workflows/fallback-report.yml
@@ -1,0 +1,51 @@
+name: Fallback Report
+
+on:
+  schedule:
+    - cron: '0 4 * * *'  # 12:00 Asia/Shanghai — 4h 23min after daily-fetch
+  workflow_dispatch:
+    inputs:
+      report_date:
+        description: 'YYYY-MM-DD (Asia/Shanghai). Defaults to today if empty.'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+
+concurrency:
+  group: fallback-report
+  cancel-in-progress: false
+
+jobs:
+  fallback:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run fallback
+        run: node scripts/fallback-report.js
+        env:
+          REPORT_DATE: ${{ inputs.report_date }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,15 @@ An automated AI news aggregation system powered by Claude Code Cloud Scheduled T
 
 ## How It Works
 
-This repo has two runtime halves:
+This repo has three runtime stages, in order:
 
-**Fetcher half** — `scripts/fetch-sources.js` runs in a daily GitHub Actions workflow (cron `37 23 * * *` UTC = 07:37 Asia/Shanghai). It reads `config.yaml`, fetches each source using route modules under `scripts/routes/`, filters each source's articles to a 30h window (slight overlap covers cron drift), and writes the snapshot to `data/fetch-cache/{YYYY-MM-DD}.json`.
+**Stage 1 — Fetcher** (`.github/workflows/daily-fetch.yml`, cron `37 23 * * *` UTC = 07:37 Asia/Shanghai). `scripts/fetch-sources.js` reads `config.yaml`, fetches each source via route modules under `scripts/routes/`, filters to a 30h window, enriches blog sources via Jina Reader (`scripts/lib/enrich.js`) and extracts full_text/linked_content where possible, and writes the snapshot to `data/fetch-cache/{YYYY-MM-DD}.json`.
 
-**Reporter half** — Claude Code Cloud Scheduled Triggers run daily / weekly / monthly. The daily trigger reads the pre-built fetch-cache snapshot (it does NOT fetch external URLs), analyzes articles, generates a markdown report in `reports/`, updates `data/history.json` and `data/health.json`, and commits/pushes.
+**Stage 2 — Analyzer** (Claude Code Cloud Scheduled Trigger, runs shortly after fetch). The trigger reads `data/fetch-cache/{date}.json` and writes per-article `{summary, category, importance, tags, practice_suggestions, thread_group_id, duplicate_of}` plus a whole-batch `trend_paragraph` to `data/analysis-cache/{date}.json`. Incrementally persisted per article — partial work survives interruptions. Commits and pushes that single file. Does NOT render the markdown report, touch history/health, or manage issues. Prompt: `docs/prompts/daily-trigger.md`; synced to the live trigger via `.claude/skills/sync-daily-trigger/`.
+
+**Stage 3 — Reporter** (`.github/workflows/build-report.yml`, triggered on push to `data/analysis-cache/**`). `scripts/build-report.js` reads fetch-cache + analysis-cache + history + health + config, does URL-hash dedup against history, merges threads, applies `duplicate_of`, renders the markdown report via `scripts/lib/render-report.js`, updates `data/history.json` + `data/health.json`, opens/closes GitHub issues for alerts, and commits+pushes the report + state files.
+
+**Safety net — Fallback** (`.github/workflows/fallback-report.yml`, cron `0 4 * * *` UTC = 12:00 CST). `scripts/fallback-report.js` checks if `reports/daily/{today}.md` exists; if not (Stage 2 or 3 failed), it renders a title+link-only report from fetch-cache alone and commits+pushes. This guarantees the email subscriber always gets something.
 
 ## Key Files
 
@@ -49,41 +53,21 @@ For newsletter-style sources (Berkeley RDI, The Batch) whose articles bundle mul
 
 After collecting across sources, perform two rounds of semantic dedup: (1) compare new articles against the past 14 days in `history.json` — if a topic was already covered, update the existing entry's `extras.also_covered_by` list instead of creating a duplicate; (2) compare new articles against each other — keep `primary` (official blogs, first-party Twitter) over `aggregator` (newsletters, roundups, personal accounts).
 
-### Analysis
-- For each new article, produce: summary (2-3 sentences), category (from config categories list), importance (1-5)
-- Apply each analysis dimension from `config.yaml` `analysis.dimensions`, respecting `condition` fields
-- Use Chinese for all analysis output
+## Rules for the Daily Trigger (post-slim)
 
-### Report Generation
-- Follow the format in `docs/report-examples/` for the corresponding report type
-- Daily: all today's articles sorted by importance
-- Weekly: aggregate from `data/history.json` articles in the past 7 days
-- Monthly: aggregate from `data/history.json` articles in the past 30 days
+The daily trigger is now "analysis-only". Its full procedure lives in `docs/prompts/daily-trigger.md`. Summary:
 
-### Health Monitoring
+- Read `data/fetch-cache/{date}.json`; abort cleanly if missing (no WebFetch fallback)
+- For each new article, produce `{summary, category, importance, tags, practice_suggestions?, thread_group_id?, duplicate_of?}`
+- Use `linked_content` > `full_text` > `quoted_tweet.text + description` > `description` as summary basis
+- Detect thread groups (self-reply chain within 5 min) and cross-source duplicates
+- Write trend_paragraph
+- Persist incrementally per article into `data/analysis-cache/{date}.json`
+- Commit that one file only
 
-The fetch-cache produces one of three statuses per source:
-- `ok` — HTTP succeeded, newest item within the source's `max_silence_hours` threshold (or no threshold declared).
-- `degraded_stale` — HTTP succeeded, but either the newest item is older than `max_silence_hours` OR the fetch returned zero items with a threshold set. Indicates an upstream freeze (e.g., a Twitter-to-RSS mirror no longer syncing, or an empty feed). Distinct from `error` because the fetcher did not throw.
-- `error` — HTTP error, parse failure, or route logic error. Message in the `error` field.
+Deterministic concerns (report rendering, history/health updates, retention, GH issues, commits of reports) are outside the trigger's scope — see `scripts/build-report.js`.
 
-For each source, update `data/health.json`:
-- `ok` → status "healthy", reset `consecutive_failures` to 0.
-- `degraded_stale` or `error` → increment `consecutive_failures`, copy the `error` field into `last_error`. If `consecutive_failures` < `alerting.consecutive_failure_threshold` from config: status "degraded". If >= threshold: status "alert" (see alert handling below).
-
-For each source with status `"alert"`:
-1. Check `gh issue list --label source-alert --state open` for an existing open issue.
-2. If none exists, open one with `gh issue create --title "CatchUp: [Source Name] 连续失败" --label source-alert --body "<diagnosis>"`. Body should include source name, URL, error type, consecutive_failure count, diagnosis, and fix suggestions.
-
-For each previously-alerting source that is now healthy, close its open issue with a recovery comment.
-
-### Data Cleanup
-- During daily runs, remove articles from `data/history.json` where `fetched_at` is older than `retention_days` from config
-
-### Committing
-- Stage all changed files: `data/history.json`, `data/health.json`, new report files
-- Commit with message: `chore(catchup): daily report YYYY-MM-DD` (or weekly/monthly)
-- Push to the repository
+Weekly and monthly triggers are unchanged (they aggregate from `data/history.json` and are less frequent; they'll be revisited if they start breaking).
 
 ## External dependencies
 

--- a/docs/prompts/daily-trigger.md
+++ b/docs/prompts/daily-trigger.md
@@ -1,220 +1,101 @@
-# CatchUp Daily Trigger Prompt
+# CatchUp Daily Trigger — Analysis Only
 
-You are the CatchUp daily news aggregator agent. Your job is to fetch AI news from configured sources, analyze each article, generate a daily markdown report, update state files, and commit/push.
+You produce structured analysis of today's AI news into `data/analysis-cache/{date}.json`. You do NOT render the report, update history, update health, or manage GitHub issues — a post-processor handles all that.
 
-Read `CLAUDE.md` first for project context and rules.
+Read `CLAUDE.md` first for project context.
 
 ## Workflow
 
-Execute these steps in order:
+### Step 1: Determine today's date
 
-### Step 1: Load Configuration
+Use Asia/Shanghai timezone, YYYY-MM-DD format. Record as `{date}`.
 
-Read `config.yaml`. Extract:
-- `sources`: list of data sources to fetch
-- `categories`: the classification categories
-- `analysis.dimensions`: extra analysis dimensions to apply
-- `output_path`: where to write reports
-- `retention_days`: how long to keep history
-- `alerting`: failure threshold and alert method
+### Step 2: Load today's fetch-cache
 
-### Step 2: Load State
+Read `data/fetch-cache/{date}.json`.
 
-Read `data/history.json`. This contains all previously processed articles keyed by SHA-256 hash of the article URL. You will use this for deduplication.
+**If the file does not exist**: abort immediately. Write one line to stderr (`fetch-cache missing for {date} — aborting`) and exit without committing anything. Do NOT attempt to WebFetch or fabricate content.
 
-Read `data/health.json`. This tracks each source's health status.
+### Step 3: Check for resume state
 
-### Step 3: Load Today's Fetch Cache
+Read `data/analysis-cache/{date}.json` if it exists. It is a partial analysis from an earlier run of this same trigger. Collect the URLs already present in `articles[].url` — call this set `analyzed_urls`.
 
-The actual source fetching has been moved to a local Node script (`scripts/fetch-sources.js`). This trigger does NOT fetch external URLs any more — it reads a pre-generated snapshot.
+If the file does not exist, `analyzed_urls` is empty and you will create the file fresh.
 
-1. Determine today's date in Asia/Shanghai timezone (format `YYYY-MM-DD`).
-2. Read the file `data/fetch-cache/{YYYY-MM-DD}.json`.
-3. **If the file does not exist**: abort the run immediately. Do NOT attempt WebFetch. Do NOT use WebSearch to fabricate content. Write a single-line error to stderr (`fetch-cache missing for YYYY-MM-DD — aborting daily run`) and exit without committing anything. Do not generate a report. The missing cache is a signal that the upstream fetch script or its scheduler needs human attention.
-4. Parse the JSON. Its shape is:
-   - `fetched_at`, `window_start`, `window_hours` — metadata
-   - `sources` — an object keyed by source name. Each entry has:
-     - `status`: `"ok"`, `"degraded_stale"`, or `"error"`
-     - `error`: null or string (descriptive message for degraded_stale / error)
-     - `fetched_count`, `filtered_count`: numbers (for diagnostics)
-     - `articles`: list of `{ title, url, published_at, description }` (already pre-filtered to `window_hours` of recency; the window is intentionally >24h to cover scheduling drift between daily runs, so expect some overlap with yesterday's articles — history-hash dedup in Step 3 handles it)
-5. For each source in `sources`:
-   - If `status === "ok"` or `status === "degraded_stale"`: iterate `articles[]`. For each article, compute SHA-256 hash of the URL. Skip if already in `data/history.json`. Collect the rest as new articles for this run. (Note: `degraded_stale` articles are still valid content — the status just flags upstream freshness for health accounting.)
-   - If `status === "error"`: note the error and the source name for Step 8 (health update). This source contributes zero articles to today's report.
+### Step 4: Iterate new articles
 
-**Newsletter splitting:** still applies. Berkeley RDI / The Batch may each produce a single newsletter article covering multiple topics. If you detect this pattern in an article's description, split it into separate entries per the existing rules (append `#topic-N` to URL, each entry independently categorized). This happens at this step, before dedup.
+For each source in `fetch-cache.sources` with `status === "ok"` or `status === "degraded_stale"`:
+- For each article in `articles[]`:
+  - If `article.url` is in `analyzed_urls`: skip.
+  - Else: perform the analysis below.
 
-### Step 3.5: Semantic Deduplication
+For each article, determine:
 
-After fetching all sources, perform two rounds of deduplication:
+1. **summary** — 2-3 Chinese sentences capturing the key point. Prioritize content sources in this order:
+   - `article.linked_content` (Twitter primary, jina-fetched blog body the tweet points to)
+   - `article.full_text` (blog, jina-fetched body)
+   - `article.quoted_tweet.text + article.description` (when quote-tweet)
+   - `article.description` (fallback)
+2. **category** — one of: `模型发布`, `研究`, `产品与功能`, `商业动态`, `政策与安全`, `教程与观点`
+3. **importance** — integer 1-5. Base score:
+   - **5** NEW MODEL RELEASE (GPT-5, Claude 5, Gemini 3, major open-weight SOTA)
+   - **4** SIGNIFICANT RESEARCH/PRODUCT (paper with empirical result, major product launch, minor version with real capability gain)
+   - **3** NOTABLE UPDATE (feature release, partnership, funding, policy/regulatory, expert deep-dive)
+   - **2** INCREMENTAL (small feature tweak, single observation)
+   - **1** LOW-SIGNAL (greeting, meme, pure RT, reply fragment)
+   Modifier: -1 if source role is `aggregator` AND raw text starts with `RT @` or `@<handle>` (pure retweet/reply).
+4. **tags** — 3-5 Chinese keywords (array).
+5. **practice_suggestions** — 1-3 concrete actionable Chinese suggestions with operating steps, ONLY if `category ∈ {模型发布, 产品与功能}`. Omit the field otherwise.
+6. **thread_group_id** — if this article is one of a self-reply chain of tweets from the same author within 5 minutes covering the same topic, assign them a shared id like `thread-{screen_name}-{YYYYMMDD-HHMM}`. Non-thread articles get `null`.
+7. **duplicate_of** — if this article covers the same topic as another article in today's batch, and that other article is from a `role: primary` source (while this one is aggregator), set `duplicate_of` to the canonical article's URL. Non-duplicates get `null`.
 
-**Round 1 — Cross-temporal dedup (new articles vs history):**
+### Step 5: Write incremental progress
 
-Aggregator sources (newsletters, roundups) often cover topics that primary sources already reported days earlier. For each new article, compare it against recent articles in `data/history.json` (within the past 14 days) by title and topic:
+**After analyzing each article**:
+- Read the current contents of `data/analysis-cache/{date}.json` (or treat as `{articles: []}` if missing).
+- Append the new article's analysis to `articles[]`.
+- Write the whole file back.
 
-- If a new article covers the same topic as an existing history entry:
-  - Do NOT create a duplicate entry
-  - Update the existing entry's `extras.also_covered_by` list to append the new source name
-  - If the existing entry had lower importance and this is the 3rd+ source covering it, bump importance by +1 (capped at 5)
-  - The new article is consumed — it will not appear in today's report as a separate entry
+Keeping progress on disk after each article means a crash or timeout does not require re-analyzing everything.
 
-**Round 2 — Same-batch dedup (new articles vs each other):**
-
-The same topic may also appear across multiple sources fetched in the same run (e.g., Google AI Blog and Berkeley RDI both fetched today). Consolidate overlapping entries:
-
-1. Compare all remaining new articles by title and content — identify groups that cover the same topic
-2. For each group of duplicates, apply source priority:
-   - Sources with `role: primary` take precedence over `role: aggregator`
-   - If multiple primary sources cover the same topic, keep the more detailed one
-   - If only aggregator sources cover a topic (no primary source), keep the aggregator entry
-3. The winning entry becomes the canonical article. Add a `also_covered_by` field in `extras` listing the other sources that covered the same topic (e.g., `["Berkeley RDI", "The Batch"]`)
-4. Being covered by multiple sources is itself a signal — add +1 to the importance score (capped at 5) for articles covered by 3+ sources
-
-Discard the duplicate entries (do not store them in history.json).
-
-### Step 4: Analyze New Articles
-
-For each new article (including split newsletter entries), determine:
-
-1. **summary**: 2-3 sentence Chinese summary capturing the key point
-2. **category**: one of the categories from config (use Chinese names)
-3. **importance**: a 1–5 integer score computed in three steps below. The goal is a **quantitative, reproducible** rubric — apply the same two articles through these steps twice, and the scores should match.
-
-**Step 4.3.a — Base score (pick the ONE bucket that best fits the article's primary content type):**
-
-- **5 — NEW MODEL RELEASE**
-  - Official launch of a new foundational model or major version (e.g., GPT-5, Claude 5, Gemini 3, Llama 5)
-  - New open-weight release that advances the SOTA
-- **4 — SIGNIFICANT RESEARCH OR PRODUCT**
-  - Research paper with empirical contribution (new method, new benchmark result, new finding)
-  - Major product launch: new platform, new app, new API, new agent
-  - Minor version of an existing model with meaningful capability improvement (e.g., Claude 4.6, GPT-4.1)
-- **3 — NOTABLE UPDATE**
-  - Feature release in an existing product (e.g., new mode, new tool integration)
-  - Industry-level news: partnerships, funding, policy, regulatory, major hires/departures
-  - Long technical thread / deep-dive analysis from a recognized expert
-- **2 — INCREMENTAL**
-  - Small feature tweak or single-point demo
-  - Single observation, commentary, or short take
-  - Follow-up discussion of a topic already covered
-- **1 — LOW-SIGNAL**
-  - Personal comment, meme, greeting, sign-off ("gm", "good night", "see you")
-  - Retweet with NO added commentary
-  - Reply fragment without standalone meaning
-
-**Step 4.3.b — Modifiers (apply BOTH, each is independent):**
-
-- **+1** if this article already exists in `data/history.json` with `extras.also_covered_by` containing **3 or more** other sources (broad coverage = real significance). This typically applies after Step 3.5 dedup bumps have taken effect.
-- **−1** if the source `role` is `aggregator` AND the raw content starts with `RT @` or `@<handle>` (pure retweet or reply fragment). Do NOT apply this penalty to original threads or standalone quote-tweets.
-
-**Step 4.3.c — Clamp to [1, 5].** Never return a score outside this range.
-
-**Anchor examples (use these to calibrate):**
-
-- "Introducing Claude Opus 4.6" (Anthropic Blog, primary) → base 5 → **5**
-- "@sama: gm" → base 1 → **1**
-- "RT @AnthropicAI: Claude for Excel is now in beta" (by @sama, aggregator) → base 3 (product announcement) → RT modifier −1 → **2**
-- "Our reward-hacking paper is out, here's what we found..." (Lilian Weng, aggregator) → base 4 (research) → **4**
-- "Anthropic raises $13B Series F" (covered by OpenAI Blog, The Batch, Berkeley RDI — 3+ sources) → base 3 → broad-coverage +1 → **4**
-- "Try DeepSeek V3.2" (Qwen RT of DeepSeek official) → base 4 (model release) → RT modifier −1 → **3**
-- "@karpathy: new blog post exploring in-context learning..." (Karpathy, aggregator, his own thread not RT) → base 3 (expert deep dive) → **3**
-
-Then apply each dimension from `config.yaml` `analysis.dimensions`:
-- Check the `condition` field — only apply if condition matches (e.g., category matches)
-- Use the `prompt` field as guidance for generating the dimension's content
-- Store result under the dimension's `name` in the article's `extras` object
-
-### Step 5: Generate Daily Report
-
-Get today's date in YYYY-MM-DD format.
-
-**Importance threshold filter:** Before writing the report, read `filtering.min_importance` from `config.yaml` (default `2` if absent). **Drop from the report any article whose `importance < min_importance`.** These dropped articles are still added to `history.json` in Step 6 (we don't lose the record), they just don't appear in today's report. Log the drop count to the report's "Data source status" section as a single line note (e.g., "共过滤 7 篇低重要度条目（importance < 2）").
-
-Create the report file at `{output_path}/daily/{YYYY-MM-DD}.md`.
-
-Follow the format in `docs/report-examples/daily-example.md` exactly:
-- Header with date
-- Overview table with article counts by category (counts are post-filter)
-- Article details sorted by importance (highest first), each with:
-  - Title as link
-  - Source, category, importance stars, tags (rendered as inline code)
-  - Summary paragraph
-  - Practice suggestions in blockquote (only if present in extras)
-- Trend summary at the bottom
-- Data source status table (includes the importance-filter drop count)
-
-### Step 6: Update History
-
-Add each newly analyzed article to `data/history.json` under `articles`, keyed by the SHA-256 hash of the URL:
-
+The article JSON shape:
 ```json
 {
-  "title": "Article Title",
-  "url": "https://...",
-  "source": "Source Name",
-  "published_at": "YYYY-MM-DD",
-  "fetched_at": "YYYY-MM-DDTHH:MM:SSZ",
+  "url": "...",
+  "source": "...",
   "summary": "...",
   "category": "...",
   "importance": 4,
-  "extras": {
-    "tags": ["tag1", "tag2"],
-    "practice_suggestions": ["suggestion1"]
-  }
+  "tags": ["..."],
+  "practice_suggestions": ["..."],
+  "thread_group_id": null,
+  "duplicate_of": null
 }
 ```
 
-Update `last_fetch` to current ISO timestamp.
+(Omit `practice_suggestions` when not applicable. Use `null` for `thread_group_id` and `duplicate_of` when not set.)
 
-### Step 7: Clean Up Old Data
+### Step 6: Trend paragraph
 
-Calculate the cutoff date: today minus `retention_days` from config.
+Once all articles are analyzed (no unprocessed URLs left), write the whole-batch **trend paragraph** (3-6 Chinese sentences synthesizing the day's themes). Update `data/analysis-cache/{date}.json` to include:
 
-Remove any article from `data/history.json` where `fetched_at` is before the cutoff date.
-
-### Step 8: Update Health Status
-
-For each source in config, update `data/health.json` using the `status` field from the fetch-cache JSON loaded in Step 3:
-
-**If the source's `status === "ok"`:**
 ```json
 {
-  "status": "healthy",
-  "last_success": "YYYY-MM-DDTHH:MM:SSZ",
-  "consecutive_failures": 0
+  "analyzed_at": "{ISO 8601 timestamp, Asia/Shanghai}",
+  "fetch_cache_ref": "data/fetch-cache/{date}.json",
+  "trend_paragraph": "...",
+  "articles": [ ... all articles analyzed above ... ]
 }
 ```
 
-**If the source's `status === "error"` or `status === "degraded_stale"`:**
-- Increment `consecutive_failures`
-- Copy the `error` field from the fetch-cache entry into `last_error`
-- If `consecutive_failures` < `alerting.consecutive_failure_threshold` from config: set `status` to `"degraded"`
-- If `consecutive_failures` >= threshold: set `status` to `"alert"` (Step 9 handles GitHub Issue creation)
+If the trigger is re-run and the file already has a `trend_paragraph` but new articles were added, regenerate the trend paragraph to reflect the full current batch.
 
-Note: `degraded_stale` means the fetch HTTP-succeeded but the newest item is older than the source's `max_silence_hours` threshold — typically an upstream mirror freeze. It shares the error accounting path above so repeated staleness eventually raises an alert. The previous fallback-aware three-state accounting is retired. Under the new architecture there is no fallback — an error (or prolonged staleness) from the fetcher is a real, actionable signal.
-
-### Step 9: Handle Alerts
-
-For each source with status `"alert"`:
-1. Use `gh issue list --label source-alert --state open` to check for existing open issues for this source
-2. If no existing issue, create one:
-   ```
-   gh issue create --title "CatchUp: [Source Name] 连续抓取失败" --label "source-alert" --body "..."
-   ```
-   Body should include: source name, URL, error type, consecutive failure count, diagnosis, and fix suggestions.
-
-For each source that recovered (was in alert/degraded, now healthy):
-1. Find the open issue for this source and close it:
-   ```
-   gh issue close <issue-number> --comment "Source recovered and is now healthy."
-   ```
-
-### Step 10: Commit and Push
+### Step 7: Commit and push
 
 ```bash
-git add data/history.json data/health.json reports/
-git commit -m "chore(catchup): daily report YYYY-MM-DD"
+git add data/analysis-cache/{date}.json
+git commit -m "chore(catchup): daily analysis {date}"
 git push
 ```
 
-Replace YYYY-MM-DD with today's actual date.
+If the file was unchanged (no new articles to add, e.g., resume after full batch was already done), skip the commit.

--- a/scripts/build-report.js
+++ b/scripts/build-report.js
@@ -1,0 +1,47 @@
+const crypto = require('node:crypto');
+
+function urlHash(url) {
+  return crypto.createHash('sha256').update(url).digest('hex');
+}
+
+function filterAlreadyReported(articles, history) {
+  const known = new Set(Object.keys(history.articles || {}));
+  return articles.filter((a) => !known.has(urlHash(a.url)));
+}
+
+function mergeThreads(articles) {
+  const byId = new Map();
+  const standalone = [];
+  for (const a of articles) {
+    if (!a.thread_group_id) { standalone.push(a); continue; }
+    const group = byId.get(a.thread_group_id) || [];
+    group.push(a);
+    byId.set(a.thread_group_id, group);
+  }
+  const merged = [];
+  for (const group of byId.values()) {
+    group.sort((x, y) => String(x.published_at).localeCompare(String(y.published_at)));
+    const [canonical, ...rest] = group;
+    const summary = [canonical.summary, ...rest.map((r) => r.summary).filter(Boolean)].filter(Boolean).join(' ');
+    merged.push({ ...canonical, summary, extras: { ...(canonical.extras || {}), thread_urls: group.map((g) => g.url) } });
+  }
+  return [...merged, ...standalone];
+}
+
+function applyDuplicateOf(articles) {
+  const byUrl = new Map(articles.map((a) => [a.url, a]));
+  const surviving = [];
+  for (const a of articles) {
+    if (!a.duplicate_of) { surviving.push(a); continue; }
+    const canonical = byUrl.get(a.duplicate_of);
+    if (!canonical) { surviving.push(a); continue; }  // canonical missing: keep the duplicate
+    canonical.also_covered_by = [...(canonical.also_covered_by || []), a.source];
+  }
+  return surviving.filter((a) => !a.duplicate_of || !byUrl.get(a.duplicate_of));
+}
+
+function filterByImportance(articles, minImportance) {
+  return articles.filter((a) => (a.importance || 0) >= minImportance);
+}
+
+module.exports = { urlHash, filterAlreadyReported, mergeThreads, applyDuplicateOf, filterByImportance };

--- a/scripts/build-report.js
+++ b/scripts/build-report.js
@@ -113,3 +113,126 @@ module.exports = {
   appendToHistory, applyRetention,
   manageAlerts,
 };
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+const { renderReport } = require('./lib/render-report');
+const { updateSourceHealth } = require('./lib/health');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const FETCH_CACHE_DIR = path.join(PROJECT_ROOT, 'data/fetch-cache');
+const ANALYSIS_CACHE_DIR = path.join(PROJECT_ROOT, 'data/analysis-cache');
+const HISTORY_PATH = path.join(PROJECT_ROOT, 'data/history.json');
+const HEALTH_PATH = path.join(PROJECT_ROOT, 'data/health.json');
+const CONFIG_PATH = path.join(PROJECT_ROOT, 'config.yaml');
+const REPORTS_DIR = path.join(PROJECT_ROOT, 'reports/daily');
+
+function shanghaiDate() {
+  return new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'Asia/Shanghai', year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date());
+}
+
+async function main() {
+  const date = process.env.REPORT_DATE || shanghaiDate();
+  const fetchCachePath = path.join(FETCH_CACHE_DIR, `${date}.json`);
+  const analysisCachePath = path.join(ANALYSIS_CACHE_DIR, `${date}.json`);
+
+  if (!fs.existsSync(fetchCachePath)) {
+    console.error(`fetch-cache missing: ${fetchCachePath}`);
+    process.exit(1);
+  }
+  if (!fs.existsSync(analysisCachePath)) {
+    console.error(`analysis-cache missing: ${analysisCachePath} — routine did not produce one; fallback-report.yml is expected to handle this`);
+    process.exit(0);  // not an error condition for this workflow; the fallback path is what handles it
+  }
+
+  const fetchCache = JSON.parse(fs.readFileSync(fetchCachePath, 'utf8'));
+  const analysisCache = JSON.parse(fs.readFileSync(analysisCachePath, 'utf8'));
+  const history = fs.existsSync(HISTORY_PATH)
+    ? JSON.parse(fs.readFileSync(HISTORY_PATH, 'utf8')) : { articles: {}, last_fetch: null };
+  const healthBefore = fs.existsSync(HEALTH_PATH)
+    ? JSON.parse(fs.readFileSync(HEALTH_PATH, 'utf8')) : {};
+  const config = yaml.load(fs.readFileSync(CONFIG_PATH, 'utf8'));
+
+  const minImportance = config.filtering?.min_importance ?? 2;
+  const retentionDays = config.retention_days || 90;
+  const failureThreshold = config.alerting?.consecutive_failure_threshold || 3;
+
+  // Step 1 — filter out articles already reported (URL-hash dedup)
+  const fresh = filterAlreadyReported(analysisCache.articles, history);
+
+  // Step 2 — thread merge (by thread_group_id)
+  const afterThreads = mergeThreads(fresh);
+
+  // Step 3 — duplicate_of → also_covered_by
+  const canonical = applyDuplicateOf(afterThreads);
+
+  // Step 4 — sort by importance desc, then published_at desc
+  canonical.sort((a, b) =>
+    (b.importance - a.importance) || String(b.published_at).localeCompare(String(a.published_at)));
+
+  // Step 5 — importance filter for the report body
+  const articlesInReport = filterByImportance(canonical, minImportance);
+
+  // Step 6 — render markdown
+  const rawFetched = Object.values(fetchCache.sources).reduce((n, s) => n + (s.articles?.length || 0), 0);
+  const sourcesWithContent = Object.values(fetchCache.sources).filter((s) => (s.articles?.length || 0) > 0).length;
+  const sourceStatuses = Object.entries(fetchCache.sources).map(([name, s]) => ({
+    name,
+    status_note: s.status === 'ok'
+      ? `✅ 正常（窗口内 ${s.articles.length} 文）`
+      : s.status === 'degraded_stale'
+        ? `⚠️ 过期（${s.error}）`
+        : `❌ 错误（${s.error}）`,
+  }));
+  const md = renderReport({
+    date,
+    articlesInReport,
+    rawFetched,
+    mergedCount: canonical.length,
+    sourcesWithContent,
+    filteredLowImportance: canonical.length - articlesInReport.length,
+    trendParagraph: analysisCache.trend_paragraph || '（无趋势段）',
+    sourceStatuses,
+  });
+  fs.mkdirSync(REPORTS_DIR, { recursive: true });
+  fs.writeFileSync(path.join(REPORTS_DIR, `${date}.md`), md);
+
+  // Step 7 — append to history
+  appendToHistory(history, canonical, analysisCache.analyzed_at || fetchCache.fetched_at);
+  const removed = applyRetention(history, new Date(), retentionDays);
+  console.error(`retention cleanup: removed ${removed} entries`);
+  fs.writeFileSync(HISTORY_PATH, JSON.stringify(history, null, 2) + '\n');
+
+  // Step 8 — update health
+  const healthAfter = {};
+  for (const [name, entry] of Object.entries(fetchCache.sources)) {
+    healthAfter[name] = updateSourceHealth(healthBefore[name], entry, fetchCache.fetched_at, failureThreshold);
+  }
+  // carry forward any entries in healthBefore that aren't in today's fetch-cache
+  for (const [name, h] of Object.entries(healthBefore)) {
+    if (!(name in healthAfter)) healthAfter[name] = h;
+  }
+  fs.writeFileSync(HEALTH_PATH, JSON.stringify(healthAfter, null, 2) + '\n');
+
+  // Step 9 — issues
+  await manageAlerts(healthAfter, healthBefore);
+
+  // Step 10 — git add / commit / push
+  const run = (c) => execSync(c, { stdio: 'inherit' });
+  run(`git add data/history.json data/health.json reports/daily/${date}.md`);
+  // If the working tree has no changes (idempotent re-run), skip commit
+  try {
+    execSync('git diff --cached --quiet', { stdio: 'ignore' });
+    console.error('no changes to commit');
+  } catch {
+    run(`git commit -m "chore(catchup): daily report ${date}"`);
+    run('git push');
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => { console.error('fatal:', err); process.exit(2); });
+}

--- a/scripts/build-report.js
+++ b/scripts/build-report.js
@@ -44,4 +44,41 @@ function filterByImportance(articles, minImportance) {
   return articles.filter((a) => (a.importance || 0) >= minImportance);
 }
 
-module.exports = { urlHash, filterAlreadyReported, mergeThreads, applyDuplicateOf, filterByImportance };
+function appendToHistory(history, articles, fetchedAtISO) {
+  for (const a of articles) {
+    const extras = { tags: a.tags || [] };
+    if (a.practice_suggestions?.length) extras.practice_suggestions = a.practice_suggestions;
+    if (a.also_covered_by?.length) extras.also_covered_by = a.also_covered_by;
+    if (a.extras?.thread_urls) extras.thread_urls = a.extras.thread_urls;
+    history.articles[urlHash(a.url)] = {
+      title: a.title,
+      url: a.url,
+      source: a.source,
+      published_at: a.published_at,
+      fetched_at: fetchedAtISO,
+      summary: a.summary,
+      category: a.category,
+      importance: a.importance,
+      extras,
+    };
+  }
+  history.last_fetch = fetchedAtISO;
+}
+
+function applyRetention(history, now, retentionDays) {
+  const cutoff = new Date(now.getTime() - retentionDays * 24 * 3600 * 1000);
+  let removed = 0;
+  for (const [k, v] of Object.entries(history.articles)) {
+    if (v.fetched_at && new Date(v.fetched_at) < cutoff) {
+      delete history.articles[k];
+      removed++;
+    }
+  }
+  return removed;
+}
+
+module.exports = {
+  urlHash,
+  filterAlreadyReported, mergeThreads, applyDuplicateOf, filterByImportance,
+  appendToHistory, applyRetention,
+};

--- a/scripts/build-report.js
+++ b/scripts/build-report.js
@@ -1,4 +1,5 @@
 const crypto = require('node:crypto');
+const { execSync } = require('node:child_process');
 
 function urlHash(url) {
   return crypto.createHash('sha256').update(url).digest('hex');
@@ -77,8 +78,38 @@ function applyRetention(history, now, retentionDays) {
   return removed;
 }
 
+function defaultShell(cmd) {
+  return execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+async function manageAlerts(health, prevHealth, { shell } = {}) {
+  const run = shell || defaultShell;
+  for (const [name, h] of Object.entries(health)) {
+    const prev = prevHealth[name] || { status: 'healthy' };
+    if (h.status === 'alert' && prev.status !== 'alert') {
+      const raw = await run(`gh issue list --label source-alert --state open --json number,title`);
+      const issues = JSON.parse(raw || '[]');
+      const hasOpen = issues.some((i) => i.title.includes(name));
+      if (!hasOpen) {
+        const title = `CatchUp: ${name} 连续抓取失败`;
+        const body = `Source: ${name}\nConsecutive failures: ${h.consecutive_failures}\nLast error: ${h.last_error}`;
+        await run(`gh issue create --title ${JSON.stringify(title)} --label source-alert --body ${JSON.stringify(body)}`);
+      }
+    }
+    if (prev.status === 'alert' && h.status === 'healthy') {
+      const raw = await run(`gh issue list --label source-alert --state open --json number,title`);
+      const issues = JSON.parse(raw || '[]');
+      const match = issues.find((i) => i.title.includes(name));
+      if (match) {
+        await run(`gh issue close ${match.number} --comment "Source recovered and is now healthy."`);
+      }
+    }
+  }
+}
+
 module.exports = {
   urlHash,
   filterAlreadyReported, mergeThreads, applyDuplicateOf, filterByImportance,
   appendToHistory, applyRetention,
+  manageAlerts,
 };

--- a/scripts/build-report.test.js
+++ b/scripts/build-report.test.js
@@ -1,0 +1,60 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  filterAlreadyReported,
+  mergeThreads,
+  applyDuplicateOf,
+  filterByImportance,
+  urlHash,
+} = require('./build-report');
+
+test('urlHash: sha256 hex of URL — 64-char, deterministic, differs per URL', () => {
+  assert.match(urlHash('https://example.com/a'), /^[0-9a-f]{64}$/);
+  assert.equal(urlHash('https://example.com/a'), urlHash('https://example.com/a'));
+  assert.notEqual(urlHash('https://example.com/a'), urlHash('https://example.com/b'));
+});
+
+test('filterAlreadyReported: drops articles whose url-hash is in history', () => {
+  const history = { articles: { [urlHash('https://example.com/old')]: { title: 'old' } } };
+  const input = [
+    { url: 'https://example.com/old' },
+    { url: 'https://example.com/new' },
+  ];
+  assert.deepEqual(filterAlreadyReported(input, history).map((a) => a.url),
+    ['https://example.com/new']);
+});
+
+test('mergeThreads: groups articles with same thread_group_id under the earliest', () => {
+  const input = [
+    { url: 'https://x.com/a/1', thread_group_id: 't1', published_at: '2026-04-22T10:02Z', summary: 'B', title: 'second' },
+    { url: 'https://x.com/a/0', thread_group_id: 't1', published_at: '2026-04-22T10:00Z', summary: 'A', title: 'first' },
+    { url: 'https://x.com/a/2', thread_group_id: 't1', published_at: '2026-04-22T10:04Z', summary: 'C', title: 'third' },
+    { url: 'https://x.com/b/0', thread_group_id: null, summary: 'D', title: 'standalone' },
+  ];
+  const out = mergeThreads(input);
+  assert.equal(out.length, 2, 'one thread merged + one standalone');
+  const thread = out.find((a) => a.url === 'https://x.com/a/0');
+  assert.ok(thread, 'canonical is earliest-published article in the thread');
+  assert.match(thread.summary, /A[\s\S]*B[\s\S]*C/, 'summaries concatenated in time order');
+});
+
+test('applyDuplicateOf: canonical gets also_covered_by entries; duplicates dropped', () => {
+  const input = [
+    { url: 'https://anthropic.com/news/x', source: 'Anthropic Blog', duplicate_of: null },
+    { url: 'https://x.com/AnthropicAI/status/1', source: 'Anthropic (Twitter)', duplicate_of: 'https://anthropic.com/news/x' },
+    { url: 'https://deeplearning.ai/the-batch/issue-350', source: 'The Batch', duplicate_of: 'https://anthropic.com/news/x' },
+  ];
+  const out = applyDuplicateOf(input);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].url, 'https://anthropic.com/news/x');
+  assert.deepEqual(out[0].also_covered_by, ['Anthropic (Twitter)', 'The Batch']);
+});
+
+test('filterByImportance: removes articles below threshold', () => {
+  const input = [
+    { url: '1', importance: 5 },
+    { url: '2', importance: 2 },
+    { url: '3', importance: 1 },
+  ];
+  assert.deepEqual(filterByImportance(input, 2).map((a) => a.url), ['1', '2']);
+});

--- a/scripts/build-report.test.js
+++ b/scripts/build-report.test.js
@@ -6,6 +6,8 @@ const {
   applyDuplicateOf,
   filterByImportance,
   urlHash,
+  appendToHistory,
+  applyRetention,
 } = require('./build-report');
 
 test('urlHash: sha256 hex of URL — 64-char, deterministic, differs per URL', () => {
@@ -57,4 +59,44 @@ test('filterByImportance: removes articles below threshold', () => {
     { url: '3', importance: 1 },
   ];
   assert.deepEqual(filterByImportance(input, 2).map((a) => a.url), ['1', '2']);
+});
+
+test('appendToHistory: adds entries keyed by url-hash, preserves existing', () => {
+  const history = { articles: { 'existing-hash': { title: 'old' } } };
+  const articles = [
+    { url: 'https://example.com/a', title: 'A', source: 'X', published_at: '2026-04-22', summary: 'sA', category: '研究', importance: 3, tags: ['t'] },
+    { url: 'https://example.com/b', title: 'B', source: 'X', published_at: '2026-04-22', summary: 'sB', category: '研究', importance: 2, tags: [] },
+  ];
+  const fetchedAtISO = '2026-04-22T00:09:08Z';
+  appendToHistory(history, articles, fetchedAtISO);
+  const keys = Object.keys(history.articles);
+  assert.equal(keys.length, 3);
+  const hashA = urlHash('https://example.com/a');
+  assert.equal(history.articles[hashA].title, 'A');
+  assert.equal(history.articles[hashA].fetched_at, fetchedAtISO);
+  assert.equal(history.articles[hashA].extras.tags.length, 1);
+});
+
+test('appendToHistory: stores extras.practice_suggestions when present', () => {
+  const history = { articles: {} };
+  const articles = [
+    { url: '1', title: 't', source: 's', published_at: 'p', summary: 'sx', category: '模型发布', importance: 5, tags: ['a'], practice_suggestions: ['step 1'] },
+  ];
+  appendToHistory(history, articles, '2026-04-22T00:00:00Z');
+  const entry = Object.values(history.articles)[0];
+  assert.deepEqual(entry.extras.practice_suggestions, ['step 1']);
+});
+
+test('applyRetention: removes entries older than cutoff', () => {
+  const history = {
+    articles: {
+      h1: { fetched_at: '2026-01-01T00:00:00Z' },
+      h2: { fetched_at: '2026-04-20T00:00:00Z' },
+      h3: { fetched_at: '2026-04-21T00:00:00Z' },
+    },
+  };
+  const now = new Date('2026-04-22T00:00:00Z');
+  const removed = applyRetention(history, now, 90);
+  assert.equal(removed, 1);
+  assert.deepEqual(Object.keys(history.articles).sort(), ['h2', 'h3']);
 });

--- a/scripts/build-report.test.js
+++ b/scripts/build-report.test.js
@@ -8,6 +8,7 @@ const {
   urlHash,
   appendToHistory,
   applyRetention,
+  manageAlerts,
 } = require('./build-report');
 
 test('urlHash: sha256 hex of URL — 64-char, deterministic, differs per URL', () => {
@@ -99,4 +100,46 @@ test('applyRetention: removes entries older than cutoff', () => {
   const removed = applyRetention(history, now, 90);
   assert.equal(removed, 1);
   assert.deepEqual(Object.keys(history.articles).sort(), ['h2', 'h3']);
+});
+
+test('manageAlerts: opens new issue when alert source has no existing open issue', async () => {
+  const shellCalls = [];
+  const shell = async (cmd) => {
+    shellCalls.push(cmd);
+    if (cmd.startsWith('gh issue list')) return '[]';  // no existing
+    if (cmd.startsWith('gh issue create')) return 'https://github.com/foo/bar/issues/42';
+    return '';
+  };
+  const health = {
+    'OpenAI Blog': { status: 'alert', consecutive_failures: 3, last_error: 'HTTP 500' },
+    'Google AI Blog': { status: 'healthy', consecutive_failures: 0 },
+  };
+  const prevHealth = { 'OpenAI Blog': { status: 'degraded', consecutive_failures: 2 } };
+  await manageAlerts(health, prevHealth, { shell });
+  assert.ok(shellCalls.some((c) => c.includes('gh issue list')));
+  assert.ok(shellCalls.some((c) => c.startsWith('gh issue create') && c.includes('OpenAI Blog')));
+});
+
+test('manageAlerts: closes issue when previously-alerting source is now healthy', async () => {
+  const shellCalls = [];
+  const shell = async (cmd) => {
+    shellCalls.push(cmd);
+    if (cmd.startsWith('gh issue list')) {
+      return JSON.stringify([{ number: 7, title: 'CatchUp: OpenAI Blog 连续抓取失败' }]);
+    }
+    return '';
+  };
+  const health = { 'OpenAI Blog': { status: 'healthy', consecutive_failures: 0 } };
+  const prevHealth = { 'OpenAI Blog': { status: 'alert', consecutive_failures: 3 } };
+  await manageAlerts(health, prevHealth, { shell });
+  assert.ok(shellCalls.some((c) => c.startsWith('gh issue close 7')));
+});
+
+test('manageAlerts: does nothing for sources that stayed healthy', async () => {
+  const shellCalls = [];
+  const shell = async (cmd) => { shellCalls.push(cmd); return '[]'; };
+  const health = { 'OpenAI Blog': { status: 'healthy', consecutive_failures: 0 } };
+  const prevHealth = { 'OpenAI Blog': { status: 'healthy', consecutive_failures: 0 } };
+  await manageAlerts(health, prevHealth, { shell });
+  assert.equal(shellCalls.length, 0);
 });

--- a/scripts/fallback-report.js
+++ b/scripts/fallback-report.js
@@ -1,0 +1,64 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const FETCH_CACHE_DIR = path.join(PROJECT_ROOT, 'data/fetch-cache');
+const REPORTS_DIR = path.join(PROJECT_ROOT, 'reports/daily');
+
+function shanghaiDate() {
+  return new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'Asia/Shanghai', year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date());
+}
+
+function renderFallbackReport(date, fetchCache) {
+  let md = `# CatchUp 日报 — ${date}（fallback，自动回退版）\n\n`;
+  md += '> Claude 分析环节未在预期窗口内产出；以下为仅标题+链接的兜底版本。\n\n---\n\n';
+  const populated = Object.entries(fetchCache.sources).filter(([, s]) => (s.articles?.length || 0) > 0);
+  if (populated.length === 0) {
+    md += '今日抓取窗口内全部数据源均无新内容。\n';
+    return md;
+  }
+  for (const [name, entry] of populated) {
+    md += `## ${name}\n\n`;
+    for (const a of entry.articles) {
+      md += `- [${a.title}](${a.url})\n`;
+    }
+    md += '\n';
+  }
+  return md;
+}
+
+async function main() {
+  const date = process.env.REPORT_DATE || shanghaiDate();
+  const reportPath = path.join(REPORTS_DIR, `${date}.md`);
+  if (fs.existsSync(reportPath)) {
+    console.error(`report already exists at ${reportPath} — fallback not needed`);
+    process.exit(0);
+  }
+  const fetchCachePath = path.join(FETCH_CACHE_DIR, `${date}.json`);
+  if (!fs.existsSync(fetchCachePath)) {
+    console.error(`fetch-cache missing for ${date}; nothing to fall back on`);
+    process.exit(1);
+  }
+  const fetchCache = JSON.parse(fs.readFileSync(fetchCachePath, 'utf8'));
+  const md = renderFallbackReport(date, fetchCache);
+  fs.mkdirSync(REPORTS_DIR, { recursive: true });
+  fs.writeFileSync(reportPath, md);
+
+  const { execSync } = require('node:child_process');
+  execSync(`git add ${reportPath}`, { stdio: 'inherit' });
+  try {
+    execSync('git diff --cached --quiet', { stdio: 'ignore' });
+    console.error('no changes to commit');
+  } catch {
+    execSync(`git commit -m "chore(catchup): fallback daily report ${date}"`, { stdio: 'inherit' });
+    execSync('git push', { stdio: 'inherit' });
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => { console.error('fatal:', err); process.exit(2); });
+}
+
+module.exports = { renderFallbackReport };

--- a/scripts/fallback-report.test.js
+++ b/scripts/fallback-report.test.js
@@ -1,0 +1,35 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { renderFallbackReport } = require('./fallback-report');
+
+test('renderFallbackReport: explicit fallback header and per-source article list', () => {
+  const fetchCache = {
+    sources: {
+      'OpenAI Blog': {
+        status: 'ok', articles: [
+          { title: 'Hello', url: 'https://openai.com/index/hello', published_at: '2026-04-22' },
+        ],
+      },
+      'Sam Altman (Twitter)': {
+        status: 'ok', articles: [
+          { title: 'tweet', url: 'https://x.com/sama/status/1', published_at: '2026-04-22' },
+        ],
+      },
+      'Berkeley RDI': { status: 'ok', articles: [] },
+    },
+  };
+  const md = renderFallbackReport('2026-04-22', fetchCache);
+  assert.match(md, /^# CatchUp 日报 — 2026-04-22（fallback/m);
+  assert.match(md, /Claude 分析环节未在预期窗口内产出/);
+  assert.match(md, /## OpenAI Blog/);
+  assert.match(md, /- \[Hello\]\(https:\/\/openai\.com\/index\/hello\)/);
+  assert.match(md, /## Sam Altman \(Twitter\)/);
+  assert.match(md, /- \[tweet\]\(https:\/\/x\.com\/sama\/status\/1\)/);
+  assert.doesNotMatch(md, /## Berkeley RDI/, 'sources with zero articles are omitted');
+});
+
+test('renderFallbackReport: zero-article day still renders with placeholder', () => {
+  const fetchCache = { sources: { 'OpenAI Blog': { status: 'ok', articles: [] } } };
+  const md = renderFallbackReport('2026-04-22', fetchCache);
+  assert.match(md, /今日抓取窗口内全部数据源均无新内容/);
+});

--- a/scripts/lib/health.js
+++ b/scripts/lib/health.js
@@ -1,0 +1,23 @@
+function updateSourceHealth(prior, fetchCacheEntry, now, failureThreshold) {
+  const prev = prior || { status: 'healthy', last_success: null, consecutive_failures: 0, last_error: null };
+  const s = fetchCacheEntry.status;
+  if (s === 'ok') {
+    return {
+      status: 'healthy',
+      last_success: now,
+      consecutive_failures: 0,
+      last_error: null,
+    };
+  }
+  // s === 'error' | 'degraded_stale' → accumulate failures
+  const failures = (prev.consecutive_failures || 0) + 1;
+  const status = failures >= failureThreshold ? 'alert' : 'degraded';
+  return {
+    status,
+    last_success: prev.last_success,
+    consecutive_failures: failures,
+    last_error: fetchCacheEntry.error || null,
+  };
+}
+
+module.exports = { updateSourceHealth };

--- a/scripts/lib/health.test.js
+++ b/scripts/lib/health.test.js
@@ -1,0 +1,49 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { updateSourceHealth } = require('./health');
+
+const NOW = '2026-04-22T00:09:08Z';
+const THRESHOLD = 3;
+
+test('ok status → healthy, consecutive_failures reset', () => {
+  const prior = { status: 'degraded', last_success: '2026-04-18T00:00:00Z', consecutive_failures: 2, last_error: 'old error' };
+  const fc = { status: 'ok', error: null };
+  const next = updateSourceHealth(prior, fc, NOW, THRESHOLD);
+  assert.deepEqual(next, {
+    status: 'healthy', last_success: NOW, consecutive_failures: 0, last_error: null,
+  });
+});
+
+test('error status → degraded when below threshold, increments failures, copies error', () => {
+  const prior = { status: 'healthy', last_success: '2026-04-20T00:00:00Z', consecutive_failures: 0, last_error: null };
+  const fc = { status: 'error', error: 'HTTP 500' };
+  const next = updateSourceHealth(prior, fc, NOW, THRESHOLD);
+  assert.deepEqual(next, {
+    status: 'degraded', last_success: '2026-04-20T00:00:00Z', consecutive_failures: 1, last_error: 'HTTP 500',
+  });
+});
+
+test('error status → alert when failures reach threshold', () => {
+  const prior = { status: 'degraded', last_success: '2026-04-19T00:00:00Z', consecutive_failures: 2, last_error: 'HTTP 500' };
+  const fc = { status: 'error', error: 'HTTP 500' };
+  const next = updateSourceHealth(prior, fc, NOW, THRESHOLD);
+  assert.equal(next.status, 'alert');
+  assert.equal(next.consecutive_failures, 3);
+});
+
+test('degraded_stale status is treated like error (increments + eventually alerts)', () => {
+  const prior = { status: 'healthy', last_success: '2026-04-20T00:00:00Z', consecutive_failures: 0, last_error: null };
+  const fc = { status: 'degraded_stale', error: 'newest item is 823h old' };
+  const next = updateSourceHealth(prior, fc, NOW, THRESHOLD);
+  assert.equal(next.status, 'degraded');
+  assert.equal(next.consecutive_failures, 1);
+  assert.equal(next.last_error, 'newest item is 823h old');
+});
+
+test('missing prior entry (new source) is treated as healthy baseline', () => {
+  const fc = { status: 'ok', error: null };
+  const next = updateSourceHealth(undefined, fc, NOW, THRESHOLD);
+  assert.deepEqual(next, {
+    status: 'healthy', last_success: NOW, consecutive_failures: 0, last_error: null,
+  });
+});

--- a/scripts/lib/render-report.js
+++ b/scripts/lib/render-report.js
@@ -23,4 +23,44 @@ function renderArticleBlock(a, idx) {
   return md;
 }
 
-module.exports = { renderArticleBlock, CATEGORIES };
+function renderReport({
+  date,
+  articlesInReport,
+  rawFetched,
+  mergedCount,
+  sourcesWithContent,
+  filteredLowImportance,
+  trendParagraph,
+  sourceStatuses,
+}) {
+  const catCounts = Object.fromEntries(CATEGORIES.map((c) => [c, 0]));
+  for (const a of articlesInReport) {
+    if (catCounts[a.category] !== undefined) catCounts[a.category]++;
+  }
+
+  let md = '';
+  md += `# CatchUp 日报 — ${date}\n\n## 今日概览\n\n`;
+  if (mergedCount === rawFetched) {
+    md += `共抓取 **${rawFetched}** 篇文章，来自 **${sourcesWithContent}** 个数据源（过滤后在报告中展示 **${articlesInReport.length}** 篇）。\n\n`;
+  } else {
+    md += `共抓取 **${rawFetched}** 篇文章（合并多推文线程后为 ${mergedCount} 条独立条目），来自 **${sourcesWithContent}** 个数据源（过滤后在报告中展示 **${articlesInReport.length}** 篇）。\n\n`;
+  }
+  md += '| 分类 | 数量 |\n|------|------|\n';
+  for (const c of CATEGORIES) md += `| ${c} | ${catCounts[c]} |\n`;
+  md += '\n---\n\n## 文章详情\n\n';
+
+  if (articlesInReport.length === 0) {
+    md += `今日 30h 抓取窗口内全部 ${sourceStatuses.length} 个数据源均未产出新内容，无条目可展示。\n\n---\n\n`;
+  } else {
+    articlesInReport.forEach((a, i) => { md += renderArticleBlock(a, i + 1); });
+  }
+
+  md += '## 今日趋势\n\n';
+  md += trendParagraph.trim() + '\n\n';
+  md += '---\n\n## 数据源状态\n\n| 数据源 | 状态 |\n|--------|------|\n';
+  for (const s of sourceStatuses) md += `| ${s.name} | ${s.status_note} |\n`;
+  md += `\n注：共过滤 ${filteredLowImportance} 篇低重要度条目（importance < 2）——这些条目仍记入 history.json。\n`;
+  return md;
+}
+
+module.exports = { renderArticleBlock, renderReport, CATEGORIES };

--- a/scripts/lib/render-report.js
+++ b/scripts/lib/render-report.js
@@ -1,0 +1,26 @@
+const CATEGORIES = ['模型发布', '研究', '产品与功能', '商业动态', '政策与安全', '教程与观点'];
+
+function stars(n) { return '⭐'.repeat(Math.max(1, Math.min(5, n))); }
+
+function renderArticleBlock(a, idx) {
+  const sourceLine = a.also_covered_by?.length
+    ? `- **来源**: ${a.source} | 📡 也被 ${a.also_covered_by.join(', ')} 报道\n`
+    : `- **来源**: ${a.source}\n`;
+  const tags = (a.tags || []).map((t) => '`' + t + '`').join(' ');
+  let md = '';
+  md += `### ${idx}. [${a.title}](${a.url})\n\n`;
+  md += sourceLine;
+  md += `- **分类**: ${a.category}\n`;
+  md += `- **重要性**: ${stars(a.importance)} (${a.importance}/5)\n`;
+  md += `- **标签**: ${tags}\n\n`;
+  md += `**摘要**: ${a.summary}\n\n`;
+  if (a.practice_suggestions && a.practice_suggestions.length) {
+    md += '> **实践建议**\n';
+    for (const s of a.practice_suggestions) md += `> - ${s}\n`;
+    md += '\n';
+  }
+  md += '---\n\n';
+  return md;
+}
+
+module.exports = { renderArticleBlock, CATEGORIES };

--- a/scripts/lib/render-report.test.js
+++ b/scripts/lib/render-report.test.js
@@ -1,0 +1,47 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { renderArticleBlock, renderReport, CATEGORIES } = require('./render-report');
+
+const SAMPLE_ARTICLE = {
+  title: 'Introducing Claude Opus 4.7',
+  url: 'https://www.anthropic.com/news/claude-opus-4-7',
+  source: 'Anthropic Blog',
+  category: '模型发布',
+  importance: 5,
+  tags: ['Claude', 'Opus', '模型发布'],
+  summary: 'Anthropic 发布 Claude Opus 4.7，在 reasoning 与工具使用上较 4.6 显著提升。',
+  practice_suggestions: ['在 Claude.ai 切换到 Opus 4.7 运行一组你已有的编码基准', '对比 Sonnet 4.6 的成本差'],
+};
+
+test('renderArticleBlock: includes title as link, source, category, stars, tags', () => {
+  const md = renderArticleBlock(SAMPLE_ARTICLE, 1);
+  assert.match(md, /### 1\. \[Introducing Claude Opus 4\.7\]\(https:\/\/www\.anthropic\.com\/news\/claude-opus-4-7\)/);
+  assert.match(md, /- \*\*来源\*\*: Anthropic Blog/);
+  assert.match(md, /- \*\*分类\*\*: 模型发布/);
+  assert.match(md, /- \*\*重要性\*\*: ⭐⭐⭐⭐⭐ \(5\/5\)/);
+  assert.match(md, /- \*\*标签\*\*: `Claude` `Opus` `模型发布`/);
+  assert.match(md, /\*\*摘要\*\*: Anthropic 发布 Claude Opus 4\.7/);
+});
+
+test('renderArticleBlock: emits practice_suggestions as blockquote when present', () => {
+  const md = renderArticleBlock(SAMPLE_ARTICLE, 1);
+  assert.match(md, /> \*\*实践建议\*\*/);
+  assert.match(md, /> - 在 Claude\.ai 切换到 Opus 4\.7/);
+  assert.match(md, /> - 对比 Sonnet 4\.6 的成本差/);
+});
+
+test('renderArticleBlock: omits practice_suggestions block when absent', () => {
+  const a = { ...SAMPLE_ARTICLE, practice_suggestions: null };
+  const md = renderArticleBlock(a, 1);
+  assert.doesNotMatch(md, /实践建议/);
+});
+
+test('renderArticleBlock: adds "也被 X, Y 报道" when also_covered_by present', () => {
+  const a = { ...SAMPLE_ARTICLE, also_covered_by: ['Berkeley RDI', 'The Batch'] };
+  const md = renderArticleBlock(a, 1);
+  assert.match(md, /\| 📡 也被 Berkeley RDI, The Batch 报道/);
+});
+
+test('CATEGORIES: matches config category order', () => {
+  assert.deepEqual(CATEGORIES, ['模型发布', '研究', '产品与功能', '商业动态', '政策与安全', '教程与观点']);
+});

--- a/scripts/lib/render-report.test.js
+++ b/scripts/lib/render-report.test.js
@@ -45,3 +45,67 @@ test('renderArticleBlock: adds "也被 X, Y 报道" when also_covered_by present
 test('CATEGORIES: matches config category order', () => {
   assert.deepEqual(CATEGORIES, ['模型发布', '研究', '产品与功能', '商业动态', '政策与安全', '教程与观点']);
 });
+
+function makeArticle(n, overrides = {}) {
+  return {
+    title: `文章 ${n}`,
+    url: `https://example.com/${n}`,
+    source: 'OpenAI Blog',
+    category: '模型发布',
+    importance: 3,
+    tags: ['t1'],
+    summary: `摘要 ${n}`,
+    ...overrides,
+  };
+}
+
+test('renderReport: header with date + totals + category table', () => {
+  const md = renderReport({
+    date: '2026-04-22',
+    articlesInReport: [makeArticle(1), makeArticle(2, { category: '研究' })],
+    rawFetched: 10,
+    mergedCount: 7,
+    sourcesWithContent: 3,
+    filteredLowImportance: 2,
+    trendParagraph: '今日主题是模型更新。',
+    sourceStatuses: [
+      { name: 'OpenAI Blog', status_note: '✅ 正常（窗口内 2 文）' },
+      { name: 'Google AI Blog', status_note: '✅ 正常（窗口内 0 文）' },
+    ],
+  });
+  assert.match(md, /^# CatchUp 日报 — 2026-04-22/);
+  assert.match(md, /共抓取 \*\*10\*\* 篇文章/);
+  assert.match(md, /合并多推文线程后为 7 条/);
+  assert.match(md, /来自 \*\*3\*\* 个数据源/);
+  assert.match(md, /过滤后在报告中展示 \*\*2\*\* 篇/);
+  assert.match(md, /\| 模型发布 \| 1 \|/);
+  assert.match(md, /\| 研究 \| 1 \|/);
+  assert.match(md, /\| 产品与功能 \| 0 \|/);
+});
+
+test('renderReport: includes each article in body, trend, source status table', () => {
+  const md = renderReport({
+    date: '2026-04-22',
+    articlesInReport: [makeArticle(1)],
+    rawFetched: 1, mergedCount: 1, sourcesWithContent: 1,
+    filteredLowImportance: 0,
+    trendParagraph: '今日 trend.',
+    sourceStatuses: [{ name: 'OpenAI Blog', status_note: '✅ 正常（窗口内 1 文）' }],
+  });
+  assert.match(md, /### 1\. \[文章 1\]/);
+  assert.match(md, /## 今日趋势[\s\S]*?今日 trend\./);
+  assert.match(md, /## 数据源状态[\s\S]*?\| OpenAI Blog \| ✅ 正常/);
+  assert.match(md, /共过滤 0 篇低重要度条目/);
+});
+
+test('renderReport: zero-article day renders placeholder section', () => {
+  const md = renderReport({
+    date: '2026-04-22',
+    articlesInReport: [],
+    rawFetched: 0, mergedCount: 0, sourcesWithContent: 0,
+    filteredLowImportance: 0,
+    trendParagraph: '今日所有数据源窗口内均无新内容。',
+    sourceStatuses: [{ name: 'OpenAI Blog', status_note: '✅ 正常（窗口内 0 文）' }],
+  });
+  assert.match(md, /今日 30h 抓取窗口内全部 \d+ 个数据源均未产出新内容/);
+});


### PR DESCRIPTION
## Summary
- Daily Claude Cloud Trigger becomes "analysis-only" — writes only `data/analysis-cache/{date}.json` with per-article analysis + trend paragraph, commits that one file, exits. Per-article checkpoint means partial work survives interruption.
- New `scripts/build-report.js` (GH Actions `.github/workflows/build-report.yml`, push-triggered): URL-hash dedup vs history, thread merge, `duplicate_of` → `also_covered_by`, importance filter, markdown render, `history.json` / `health.json` updates, retention cleanup, GH issue alerts, commit+push.
- New `scripts/fallback-report.js` (`.github/workflows/fallback-report.yml`, cron 04:00 UTC = 12:00 CST): if today's report is missing, renders title+link-only digest from fetch-cache and commits — guaranteed email delivery floor.
- Prompt `docs/prompts/daily-trigger.md` rewritten to slim version (220 → 59 lines).
- `CLAUDE.md` + `sync-daily-trigger/SKILL.md` updated for the three-stage + fallback pipeline.
- Spec: `docs/superpowers/specs/2026-04-22-enrichment-and-routine-slim-design.md` (Phase 2).
- Depends on PR 1 (enrichment, already merged).

## Post-merge action required
Run \`/sync-daily-trigger\` from an interactive Claude Code session to push the new prompt to the live Cloud Scheduled Trigger. Without this, the old 11-step prompt is still running and the analysis-cache flow is inactive.

## Test plan
- [x] \`node --test scripts/\` — 67 tests pass
- [x] Dry-run \`build-report.js\` with synthetic analysis-cache → renders report, updates history/health, retention cleanup runs
- [x] Dry-run \`fallback-report.js\`: existing report → no-op; missing → renders minimal title+link report
- [ ] After merge + \`/sync-daily-trigger\`: observe the next daily run produces analysis-cache; build-report workflow fires on the push; report lands in email
- [ ] Observe at least one day where routine dies; fallback fires at 12:00 CST; fallback report emailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)