### PR TITLE
chore(catchup): produce daily analysis cache for 2026-06-12

### DIFF
--- a/data/analysis-cache/2026-06-12.json
+++ b/data/analysis-cache/2026-06-12.json
@@ -1,0 +1,790 @@
+{
+  "analyzed_at": "2026-06-12T10:30:10.087925+08:00",
+  "fetch_cache_ref": "data/fetch-cache/2026-06-12.json",
+  "trend_paragraph": "- **代理工具扩展**：Grok Build插件市场和Claude托管代理都在把编码助手推进到可部署、可运维的代理平台。\n- **AI治理升温**：OpenAI支持欧盟透明度准则，Anthropic则呼吁前沿模型第三方测试与更强公共能力。\n- **产业落地加速**：OpenAI与BBVA、Oracle合作，Anthropic与DXC合作，显示企业AI采购正进入云承诺和关键系统层。\n- **研究走向真实场景**：TacticAI、塞拉利昂教育实验和Codex黑洞仿真都强调从基准转向现场问题。",
+  "articles": [
+    {
+      "url": "https://x.com/ClaudeDevs/status/2065192057535373473",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude Devs发布足球梗短帖",
+      "summary": "Claude Devs 只发布了「/goooooal」和足球表情，未附带可分析的功能、版本或技术说明。当前更像社区互动或轻量预告，暂不能判断与 Claude Code 的实际更新有关。",
+      "category": "教程与观点",
+      "importance": 1,
+      "tags": [
+        "Claude",
+        "开发者社区",
+        "社交动态"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/xai/status/2065168019891073260",
+      "source": "xAI (Twitter)",
+      "title": "Grok Build接入Sentry插件",
+      "summary": "xAI 宣布 Grok Build 插件市场测试版中的 Sentry 插件可用于让智能体查找并修复错误、分析堆栈追踪和分流告警。这显示 Grok Build 正把终端智能体从代码生成扩展到可观测性与生产故障处理流程。",
+      "category": "产品与功能",
+      "importance": 3,
+      "tags": [
+        "Grok Build",
+        "插件市场",
+        "Sentry",
+        "智能体"
+      ],
+      "practice_suggestions": [
+        "在测试仓库中接入 Sentry 插件，验证它对真实异常、堆栈追踪和告警优先级的解释是否能减少排障时间。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": "https://x.com/xai/status/2065099299541893577",
+      "angle": "Sentry排错插件"
+    },
+    {
+      "url": "https://blog.google/innovation-and-ai/infrastructure-and-cloud/global-network/virginia-community-investments/",
+      "source": "Google AI Blog",
+      "title": "Google加码弗吉尼亚社区投资",
+      "summary": "Google 宣布在弗吉尼亚扩大社区投入，围绕数据中心与基础设施增长支持本地就业、技工培养和能源可负担性。计划包括资助电气学徒培训、到 2030 年新增 2,741 名学徒培训容量，并推出 1,500 万美元能源影响基金。",
+      "category": "商业动态",
+      "importance": 2,
+      "tags": [
+        "Google",
+        "数据中心",
+        "能源",
+        "弗吉尼亚"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/sama/status/2065160791205310565",
+      "source": "Sam Altman (Twitter)",
+      "title": "Sam Altman回应合作期待",
+      "summary": "Sam Altman 转发并表示「really looking forward to working together」，但原引用内容只有链接，缺少可确认的合作对象与细节。该条目前只能视为潜在合作信号，尚不足以判断产品、模型或组织层面的影响。",
+      "category": "商业动态",
+      "importance": 1,
+      "tags": [
+        "OpenAI",
+        "Sam Altman",
+        "合作信号"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/xai/status/2065143638838157559",
+      "source": "xAI (Twitter)",
+      "title": "Grok Build支持Vercel插件",
+      "summary": "xAI 表示 Grok Build 的 Vercel 插件可用于部署生产环境、启动沙盒或用 Shadcn 构建应用。它把智能体开发链路直接连接到托管与前端脚手架，适合快速原型到上线的闭环实验。",
+      "category": "产品与功能",
+      "importance": 3,
+      "tags": [
+        "Grok Build",
+        "Vercel",
+        "部署",
+        "Shadcn"
+      ],
+      "practice_suggestions": [
+        "用一个小型前端项目测试从提示词生成、沙盒预览到 Vercel 部署的端到端流程，并记录人工审核与回滚环节。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": "https://x.com/xai/status/2065099299541893577",
+      "angle": "Vercel部署插件"
+    },
+    {
+      "url": "https://x.com/xai/status/2065119714658152592",
+      "source": "xAI (Twitter)",
+      "title": "Grok Build上线MongoDB插件",
+      "summary": "xAI 宣布 MongoDB 插件已进入 Grok Build 插件市场，可通过单个提示探索数据、优化数据库性能并构建高性能向量搜索系统。这使 Grok Build 更接近面向全栈与 RAG 应用的开发运维助手。",
+      "category": "产品与功能",
+      "importance": 3,
+      "tags": [
+        "Grok Build",
+        "MongoDB",
+        "向量搜索",
+        "数据库"
+      ],
+      "practice_suggestions": [
+        "选取一份非敏感样例数据，让插件生成索引、查询与向量检索方案，再用人工基准测试验证性能和安全边界。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": "https://x.com/xai/status/2065099299541893577",
+      "angle": "MongoDB数据插件"
+    },
+    {
+      "url": "https://x.com/xai/status/2065099299541893577",
+      "source": "xAI (Twitter)",
+      "title": "Grok Build插件市场开放测试",
+      "summary": "xAI 将 Grok Build Plugin Marketplace 开放 beta，让开发者在同一代理构建环境中调用 MongoDB、Vercel、Sentry、Cloudflare 等插件。MongoDB 侧重数据探索、数据库优化与应用构建，Vercel 负责生产部署、沙箱与 Shadcn 应用生成，Sentry 则用于定位错误、分析堆栈并整理问题。这个更新把 Grok Build 从单一编码助手推进到可连接开发、部署和运维工具链的代理平台。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "Grok Build",
+        "插件市场",
+        "开发者工具",
+        "MongoDB",
+        "Vercel",
+        "Sentry"
+      ],
+      "practice_suggestions": [
+        "试用 Grok Build beta 时优先连接现有 MongoDB/Vercel/Sentry 项目，验证端到端开发闭环。",
+        "把插件权限限定在测试项目或沙箱环境，观察代理读写数据库和部署生产环境的边界。",
+        "记录插件调用的失败案例，补充团队内部的代理工具使用规范。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/GoogleDeepMind/status/2065093485120700880",
+      "source": "Google DeepMind (Twitter)",
+      "title": "TacticAI用图神经网络建模球场",
+      "summary": "Google DeepMind 介绍 TacticAI 将球场上的 22 名球员视为图节点，并用球员间物理互动构成连接。该方法让俱乐部数据团队可实时拖放球员位置，测试不同防守布局。",
+      "category": "研究",
+      "importance": 3,
+      "tags": [
+        "TacticAI",
+        "图神经网络",
+        "足球分析",
+        "仿真"
+      ],
+      "thread_group_id": "thread-GoogleDeepMind-20260611-1527",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/GoogleDeepMind/status/2065093488627073266",
+      "source": "Google DeepMind (Twitter)",
+      "title": "TacticAI连接体育与机器人研究",
+      "summary": "Google DeepMind 强调足球比赛是部分可观测、多模态和连续空间决策问题的典型场景。TacticAI 在这类实时动态系统上的进展，可能迁移到机器人、计算机游戏等需要空间推理与策略预测的领域。",
+      "category": "研究",
+      "importance": 3,
+      "tags": [
+        "TacticAI",
+        "多模态",
+        "机器人",
+        "空间推理"
+      ],
+      "thread_group_id": "thread-GoogleDeepMind-20260611-1527",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/GoogleDeepMind/status/2065093482088169719",
+      "source": "Google DeepMind (Twitter)",
+      "title": "DeepMind与Palmeiras推进TacticAI",
+      "summary": "Google DeepMind 宣布与巴西足球俱乐部 Palmeiras 合作，后者成为首个实质性基于 TacticAI 开展建设的足球俱乐部。TacticAI 可模拟场上情景，并提前最多 8 秒预测开放比赛动态。",
+      "category": "研究",
+      "importance": 3,
+      "tags": [
+        "Google DeepMind",
+        "TacticAI",
+        "Palmeiras",
+        "体育AI"
+      ],
+      "thread_group_id": "thread-GoogleDeepMind-20260611-1527",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2065080009203892302",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude托管代理支持环境变量凭证",
+      "summary": "Claude Managed Agents 新增环境变量凭证类型，可让代理通过 CLI、SDK 或直接 API 调用使用依赖环境变量认证的服务。Claude 不会直接接触密钥，凭证会在网络边界被安全注入，降低自动化任务接入外部系统的泄露风险。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "Claude托管代理",
+        "环境变量",
+        "凭证安全",
+        "企业集成"
+      ],
+      "practice_suggestions": [
+        "在托管代理中优先用环境变量凭证接入云服务和内部 API，并按最小权限拆分密钥；上线前记录哪些工具会读取这些变量，便于审计代理的外部访问边界。"
+      ],
+      "thread_group_id": "thread-ClaudeDevs-20260611-1433",
+      "duplicate_of": "https://x.com/ClaudeDevs/status/2065080005328249086",
+      "angle": "安全凭证类型"
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2065080010604740930",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude Code可部署托管代理",
+      "summary": "Claude Code 现在可帮助用户搭建 Claude Managed Agent 部署。内置「/claude-api」技能了解相关 API，配合 ant CLI 为 Claude 提供操作接口，使从代码环境发起代理部署更顺畅。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "Claude Code",
+        "托管代理",
+        "部署自动化",
+        "开发工具"
+      ],
+      "practice_suggestions": [
+        "可把一次标准托管代理部署流程整理成 Claude Code 项目任务，让它生成配置、调用 CLI 并产出检查清单；团队应保留人工审批步骤，特别是凭证、网络和定时任务配置。"
+      ],
+      "thread_group_id": "thread-ClaudeDevs-20260611-1433",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2065080005328249086",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude托管代理新增定时部署与凭证",
+      "summary": "Claude Managed Agents 新增两项面向自动化运行的能力：定时部署可按 cron、间隔或一次性时间触发任务，环境变量凭证类型则让代理安全使用外部 CLI、SDK 与 API。配套说明还强调 Claude Code 可通过内置 /claude-api skill 帮用户搭建托管代理部署。整体上，这使 Claude Code 工作流更接近可持续运行的云端代理，而不只是一次性交互式编码助手。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "Claude Managed Agents",
+        "Claude Code",
+        "定时部署",
+        "环境变量凭证",
+        "自动化代理"
+      ],
+      "practice_suggestions": [
+        "把重复性仓库维护任务改造成定时托管代理，先从低风险只读检查开始。",
+        "为代理使用的第三方 CLI/API 建立最小权限环境变量凭证，避免复用个人长期密钥。",
+        "用 /claude-api skill 生成部署脚手架后，补充日志、失败告警和回滚路径。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/AnthropicAI/status/2065057393927467084",
+      "source": "Anthropic (Twitter)",
+      "title": "Anthropic推出Claude公益奖学金",
+      "summary": "Anthropic 发布 Claude Corps 全国性 fellowship 项目，面向职业早期人群，并将其匹配到美国非营利组织。项目计划培训 1000 人使用 Claude，并付费支持他们用 AI 推进所在机构的公益使命。",
+      "category": "商业动态",
+      "importance": 2,
+      "tags": [
+        "Anthropic",
+        "Claude Corps",
+        "公益组织",
+        "AI培训"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": "https://www.anthropic.com/news/claude-corps",
+      "angle": "项目发布入口"
+    },
+    {
+      "url": "https://x.com/GoogleDeepMind/status/2065031279213441309",
+      "source": "Google DeepMind (Twitter)",
+      "title": "DeepMind设立多智能体研究基金",
+      "summary": "Google DeepMind 联合 Schmidt Sciences、Cooperative AI Foundation、ARIA 等机构推出 1000 万美元研究基金。该基金聚焦数百万 AI 智能体相互交互时可能涌现的集体行为，意在提前理解多智能体生态的风险与机制。",
+      "category": "研究",
+      "importance": 3,
+      "tags": [
+        "多智能体",
+        "集体行为",
+        "研究基金",
+        "AI安全"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2064949876463645026",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude公开Fable 5安全回退",
+      "summary": "Claude Devs 表示将让 Fable 5 面向前沿 LLM 开发的安全防护变得可见，触发时会明确回退到 Opus 4.8，API 请求也将返回拒绝原因。团队承认此前采用不可见防护是错误权衡，并提示在分类器调优期间可能出现更多误报，可通过反馈和申诉渠道报告。",
+      "category": "政策与安全",
+      "importance": 4,
+      "tags": [
+        "Claude",
+        "Fable 5",
+        "安全防护",
+        "模型回退",
+        "误报申诉"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/demishassabis/status/2064873362799600042",
+      "source": "Demis Hassabis (Twitter)",
+      "title": "Google发布DiffusionGemma开放模型",
+      "summary": "DiffusionGemma 是 Google Gemma 团队推出的实验性开放模型，采用文本扩散思路，不再逐 token 顺序生成，而是并行生成整块文本。Demis Hassabis 称其速度很快，比其他 Gemma 4 模型快 4 倍，并以 Apache 2.0 许可发布。",
+      "category": "模型发布",
+      "importance": 4,
+      "tags": [
+        "DiffusionGemma",
+        "Gemma",
+        "文本扩散",
+        "开源模型",
+        "Apache 2.0"
+      ],
+      "practice_suggestions": [
+        "适合评估低延迟生成场景，如批量草稿、实时补全或边缘端文本生成；测试时应同时比较速度、连贯性和长文本稳定性，不要只看吞吐指标。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://openai.com/index/openai-to-acquire-ona",
+      "source": "OpenAI Blog",
+      "title": "OpenAI收购Ona强化Codex云环境",
+      "summary": "OpenAI 宣布计划收购 Ona，把其安全云执行与编排技术纳入 Codex 生态。Ona 的持久、可复现云环境将支持 Codex 在客户控制的基础设施中长时间运行，满足企业对凭证范围、日志、治理和安全边界的要求。",
+      "category": "商业动态",
+      "importance": 4,
+      "tags": [
+        "OpenAI",
+        "Ona",
+        "Codex",
+        "云执行环境",
+        "企业代理"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://openai.com/index/supporting-eu-trustworthy-ai-ecosystem",
+      "source": "OpenAI Blog",
+      "title": "OpenAI支持欧盟AI透明度准则",
+      "summary": "OpenAI 宣布支持欧盟关于 AI 生成内容透明度的实践准则，称其是落实欧盟 AI 法案和建设可信数字生态的重要步骤。文章强调 OpenAI 会继续推进 C2PA 元数据、SynthID 水印、公开验证工具和开放标准协作，但也承认来源信号在传播中可能丢失，仍需生态共同完善。",
+      "category": "政策与安全",
+      "importance": 3,
+      "tags": [
+        "欧盟AI法案",
+        "内容来源",
+        "C2PA",
+        "SynthID",
+        "透明度"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://openai.com/index/using-codex-to-simulate-black-holes",
+      "source": "OpenAI Blog",
+      "title": "Codex辅助黑洞仿真研究",
+      "summary": "OpenAI 介绍天体物理学家 Chi-kwan Chan 如何用 Codex 推导和测试新的数值算法，以改进黑洞周围等离子体仿真。Codex 生成的候选方案需要经过物理解释、已知解比对和反复测试，展示了 AI 在可验证科学探索中的辅助价值。",
+      "category": "教程与观点",
+      "importance": 2,
+      "tags": [
+        "Codex",
+        "科学计算",
+        "黑洞仿真",
+        "数值算法",
+        "可验证研究"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://openai.com/index/bbva",
+      "source": "OpenAI Blog",
+      "title": "BBVA与OpenAI深化银行AI转型",
+      "summary": "BBVA与OpenAI建立战略合作，把AI嵌入客户体验、风控、运营、软件开发和员工日常工作。其ChatGPT Enterprise部署已扩展到全球10万多名员工，并形成「The Eight」路线图、AI冠军网络和数万个定制GPT，用于信贷分析、营销、客户服务等场景。",
+      "category": "商业动态",
+      "importance": 3,
+      "tags": [
+        "企业AI",
+        "银行",
+        "ChatGPT Enterprise",
+        "OpenAI",
+        "数字化转型"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://www.anthropic.com/news/claude-corps",
+      "source": "Anthropic Blog",
+      "title": "Anthropic推出Claude Corps公益项目",
+      "summary": "Anthropic 推出 Claude Corps，将早期职业人才与非营利组织、公共机构和社会影响项目配对，帮助他们用 Claude 解决教育、健康、经济机会等问题。官方说明强调该项目既是人才培养计划，也是让更多公共利益场景直接接触前沿 AI 的渠道。相关社交发布补充了项目的全国 fellowship 定位和申请入口。",
+      "category": "商业动态",
+      "importance": 3,
+      "tags": [
+        "Claude Corps",
+        "AI公益",
+        "人才培养",
+        "Anthropic",
+        "社会影响"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://www.anthropic.com/news/dxc-anthropic-alliance",
+      "source": "Anthropic Blog",
+      "title": "DXC将Claude带入关键行业系统",
+      "summary": "Anthropic与DXC Technology达成多年全球联盟，DXC将培训数万名Claude认证前线工程师，把Claude部署到银行、航空、保险、制造和政府等受监管行业的核心系统中。DXC称其AI原生托管服务平台OASIS由Claude生成超过95%的代码，并已服务50多家客户，联盟将首先覆盖保险、遗留系统现代化、网络安全和应用服务。",
+      "category": "商业动态",
+      "importance": 3,
+      "tags": [
+        "Claude",
+        "DXC",
+        "企业服务",
+        "受监管行业",
+        "系统现代化"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/trq212/status/2064828193446740023",
+      "source": "Thariq (Twitter)",
+      "title": "Fable展示Claude Code工作流变化",
+      "summary": "这条推文补充了一个参考视频，并引用Claude开发者关于Claude Fable 5改变Claude Code团队日常工作的说明。重点从“验证Claude是否正确完成任务”转向“验证它是否在做正确的工作”，暗示代理式编码流程对产品团队协作方式的改变。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "Claude Code",
+        "Fable",
+        "代理式编码",
+        "开发工作流"
+      ],
+      "practice_suggestions": [
+        "可借鉴其评审思路，把代码代理任务拆成目标确认、执行监控和结果验收三段；在团队内部设计检查清单，减少只看代码 diff 而忽略任务方向的风险。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": "https://x.com/trq212/status/2064826394589442448",
+      "angle": "参考视频补充"
+    },
+    {
+      "url": "https://x.com/trq212/status/2064826541947940910",
+      "source": "Thariq (Twitter)",
+      "title": "Fable视频制作流程公开演示文稿",
+      "summary": "作者分享了前一条Fable视频制作说明的演示文稿，方便读者自行查看其自动化编辑流程细节。该线程围绕用AI编写代码、调用转录、ffmpeg、Figma MCP和Remotion来生成发布视频，展示了非传统视频编辑工作流。",
+      "category": "教程与观点",
+      "importance": 3,
+      "tags": [
+        "Fable",
+        "视频自动化",
+        "Remotion",
+        "Figma MCP",
+        "创作工具"
+      ],
+      "thread_group_id": "thread-trq212-20260610-2145",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/trq212/status/2064826394589442448",
+      "source": "Thariq (Twitter)",
+      "title": "Fable展示自剪发布视频流程",
+      "summary": "Thariq 展示了如何用 Fable 编辑 Fable 自己的发布视频，把产品演示、设计素材和迭代流程串成一个可复用案例。后续补充提供了演示文稿和参考视频，方便用户复盘具体剪辑步骤。这个案例的价值不在单次视频，而在展示生成式创作工具如何参与自身产品发布素材的制作。",
+      "category": "教程与观点",
+      "importance": 2,
+      "tags": [
+        "Fable",
+        "视频生成",
+        "创作工作流",
+        "产品发布",
+        "案例复盘"
+      ],
+      "practice_suggestions": [
+        "可尝试把重复性视频制作步骤脚本化，例如转录、素材切片、字幕和渲染；团队应保留人工抽检节点，重点检查节奏、品牌一致性和版权素材使用。"
+      ],
+      "thread_group_id": "thread-trq212-20260610-2145",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://openai.com/index/openai-on-oracle-cloud",
+      "source": "OpenAI Blog",
+      "title": "OpenAI模型与Codex接入Oracle云承诺",
+      "summary": "OpenAI与Oracle合作，让OCI客户可在未来数周用符合条件的Oracle Universal Credits访问OpenAI前沿模型和Codex。该安排把采购、治理和云承诺纳入企业既有流程，降低在受控环境中部署AI应用、自动化工作流和开发工具的阻力。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "OpenAI",
+        "Oracle Cloud",
+        "Codex",
+        "企业采购",
+        "云服务"
+      ],
+      "practice_suggestions": [
+        "已有OCI承诺的企业可评估把模型调用和Codex试点纳入现有云预算；落地前应确认积分适用范围、数据治理边界、权限模型和与现有开发平台的集成路径。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/GoogleDeepMind/status/2064785577593995272",
+      "source": "Google DeepMind (Twitter)",
+      "title": "DeepMind评估AI对学习行为影响",
+      "summary": "Google DeepMind表示，其研究不只看考试分数，而是观察学生使用AI后的行为变化。八周结果显示，学生更常用Gemini理解概念而非直接找答案，其中关于解题方法的查询比例从68%升至90%。",
+      "category": "研究",
+      "importance": 3,
+      "tags": [
+        "教育AI",
+        "Gemini",
+        "学习行为",
+        "Google DeepMind",
+        "评估方法"
+      ],
+      "thread_group_id": "thread-GoogleDeepMind-20260610-1903",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/GoogleDeepMind/status/2064785573852672275",
+      "source": "Google DeepMind (Twitter)",
+      "title": "DeepMind研究AI辅助塞拉利昂教师",
+      "summary": "Google DeepMind介绍在塞拉利昂开展的教育AI研究，背景是学生人数快速增长而教师供给不足。研究强调AI应作为教师伙伴，扩大教育者覆盖面，同时不替代教师的专业知识和关键技能。",
+      "category": "研究",
+      "importance": 3,
+      "tags": [
+        "教育AI",
+        "塞拉利昂",
+        "教师支持",
+        "Google DeepMind",
+        "Gemini"
+      ],
+      "thread_group_id": "thread-GoogleDeepMind-20260610-1903",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/AnthropicAI/status/2064783425807187970",
+      "source": "Anthropic (Twitter)",
+      "title": "Anthropic称将扩展AI社会影响项目",
+      "summary": "Anthropic在线程结尾表示，当前项目不足以完全应对高级AI带来的挑战，但代表了公司的投入信号。公司称未来数月和数年会继续扩大相关工作，语境上与其围绕AI工作影响、公益培训和政策框架的行动相呼应。",
+      "category": "政策与安全",
+      "importance": 2,
+      "tags": [
+        "Anthropic",
+        "AI影响",
+        "治理",
+        "就业",
+        "社会责任"
+      ],
+      "thread_group_id": "thread-AnthropicAI-20260610-1855",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/AnthropicAI/status/2064783424251101553",
+      "source": "Anthropic (Twitter)",
+      "title": "Anthropic设1.5亿美元AI奖学金",
+      "summary": "Anthropic预告将推出1.5亿美元全国性奖学金项目，面向职业早期人群，帮助他们把AI收益带到美国各地社区。该项目与其更广泛的AI政策倡议相配套，强调人才培养和社会扩散。",
+      "category": "商业动态",
+      "importance": 3,
+      "tags": [
+        "Anthropic",
+        "AI教育",
+        "奖学金",
+        "社区应用"
+      ],
+      "thread_group_id": "thread-AnthropicAI-20260610-1855",
+      "duplicate_of": "https://x.com/AnthropicAI/status/2064783418844762489",
+      "angle": "社会项目配套"
+    },
+    {
+      "url": "https://x.com/AnthropicAI/status/2064783418844762489",
+      "source": "Anthropic (Twitter)",
+      "title": "Anthropic提出AI指数级政策议程",
+      "summary": "Anthropic 围绕「AI 指数级发展」发布政策主张，认为仅靠透明度要求已不足以应对前沿模型能力快速上升，需要更强的第三方测试、风险治理和公共部门能力建设。Dario Amodei 的配套文章把就业、科学进展、地缘政治与模型风险放在同一框架下，呼吁跨党派尽快行动。官方线程还把 1.5 亿美元 fellowship 等社会影响项目纳入整体治理组合，强调这些项目只是更大政策挑战的一部分。",
+      "category": "政策与安全",
+      "importance": 4,
+      "tags": [
+        "AI政策",
+        "前沿模型治理",
+        "第三方测试",
+        "Anthropic",
+        "就业影响",
+        "公共部门"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/DarioAmodei/status/2064781785033244851",
+      "source": "Dario Amodei (Twitter)",
+      "title": "Dario呼吁跨党派AI政策行动",
+      "summary": "Dario Amodei强调，这组AI政策主张具有跨政治光谱的常识吸引力。他认为越早采取行动，社会就越早能共享AI带来的收益。",
+      "category": "政策与安全",
+      "importance": 3,
+      "tags": [
+        "Dario Amodei",
+        "AI政策",
+        "公共利益",
+        "治理共识"
+      ],
+      "thread_group_id": "thread-DarioAmodei-20260610-1848",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/DarioAmodei/status/2064781782877458612",
+      "source": "Dario Amodei (Twitter)",
+      "title": "Anthropic提AI风险与就业框架",
+      "summary": "Dario Amodei表示，Anthropic随文章发布了政府应对前沿AI风险的提案，以及针对AI引发就业替代的政策框架。公司还计划为相关工作提供大量资金支持，显示其将政策建议与资金支持绑定。",
+      "category": "政策与安全",
+      "importance": 4,
+      "tags": [
+        "前沿AI",
+        "风险监管",
+        "就业影响",
+        "政策框架"
+      ],
+      "thread_group_id": "thread-DarioAmodei-20260610-1848",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/DarioAmodei/status/2064781780562137306",
+      "source": "Dario Amodei (Twitter)",
+      "title": "Dario论AI对经济与地缘影响",
+      "summary": "Dario Amodei称其文章还讨论AI陡峭发展轨迹对就业、经济、科学进步、公民自由和地缘政治的影响。这表明Anthropic的政策论述已从模型安全扩展到更广泛的社会制度议题。",
+      "category": "政策与安全",
+      "importance": 3,
+      "tags": [
+        "AI影响",
+        "就业经济",
+        "科学进步",
+        "地缘政治"
+      ],
+      "thread_group_id": "thread-DarioAmodei-20260610-1848",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/DarioAmodei/status/2064781778599268818",
+      "source": "Dario Amodei (Twitter)",
+      "title": "Dario主张前沿模型强制第三方测试",
+      "summary": "Dario Amodei表示，除透明度要求外，前沿模型现在应接受针对网络、生物和自主性风险的强制第三方测试。他还提出测试机制应具备阻止或撤销高灾难风险模型部署的权力。",
+      "category": "政策与安全",
+      "importance": 4,
+      "tags": [
+        "第三方测试",
+        "模型安全",
+        "生物风险",
+        "部署监管"
+      ],
+      "thread_group_id": "thread-DarioAmodei-20260610-1848",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/DarioAmodei/status/2064781776904663043",
+      "source": "Dario Amodei (Twitter)",
+      "title": "Anthropic称透明度监管已不足",
+      "summary": "Dario Amodei指出，Anthropic长期支持前沿AI透明度要求，因为过去风险还不够清晰，难以做精确监管。但他现在认为，仅靠透明度已经不足以应对快速显现的前沿模型风险。",
+      "category": "政策与安全",
+      "importance": 4,
+      "tags": [
+        "透明度",
+        "AI监管",
+        "前沿模型",
+        "风险治理"
+      ],
+      "thread_group_id": "thread-DarioAmodei-20260610-1848",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/DarioAmodei/status/2064781775247950326",
+      "source": "Dario Amodei (Twitter)",
+      "title": "Dario发布AI指数级政策文章",
+      "summary": "Dario Amodei发布新文章「Policy on the AI Exponential」，称AI进展远快于政策流程原本能处理的速度。文章旨在说明技术所处阶段，并提出缩小技术发展与政策响应差距所需的行动。",
+      "category": "政策与安全",
+      "importance": 4,
+      "tags": [
+        "Dario Amodei",
+        "AI指数增长",
+        "政策滞后",
+        "AI治理"
+      ],
+      "thread_group_id": "thread-DarioAmodei-20260610-1848",
+      "duplicate_of": "https://x.com/AnthropicAI/status/2064783418844762489",
+      "angle": "长文政策框架"
+    },
+    {
+      "url": "https://x.com/xai/status/2064777588036530309",
+      "source": "xAI (Twitter)",
+      "title": "xAI推出Grok Voice低价语音能力",
+      "summary": "xAI称Grok Voice在语音时机、语调和温暖感上达到领先表现，并以明显低于竞争对手的价格提供。其引用的EVA-Bench结果称「Grok Voice Think Fast 1.0」位于准确率与体验权衡的帕累托前沿。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "xAI",
+        "Grok Voice",
+        "语音智能体",
+        "API定价"
+      ],
+      "practice_suggestions": [
+        "关注x.ai语音API的延迟、价格和中文/多语言表现；适合在客服、语音助手和实时交互原型中做小规模对比测试。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/xai/status/2064771445260230840",
+      "source": "xAI (Twitter)",
+      "title": "eToro智能体接入xAI模型与实时数据",
+      "summary": "xAI介绍eToro的智能体Tori如何利用其模型和实时数据，帮助消费者分析市场情绪。这更像是xAI在金融场景中的落地案例，展示Grok能力可被嵌入垂直应用。",
+      "category": "产品与功能",
+      "importance": 3,
+      "tags": [
+        "xAI",
+        "eToro",
+        "金融智能体",
+        "市场情绪"
+      ],
+      "practice_suggestions": [
+        "可参考其模式评估金融类智能体：模型输出应与实时行情、风险提示和合规审查分离，避免把情绪分析直接包装成投资建议。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/claudeai/status/2064757537992249734",
+      "source": "Claude (Twitter)",
+      "title": "Claude讲述Cursor创始人成长",
+      "summary": "Claude 在「The Problem Solvers」系列中介绍 Cursor 联合创始人 Michael Truell，从少年时期接触编程到带领公司两年内从 15 人扩张到 700 人。推文强调 Cursor 已被超过 60% 的财富 500 强用于 AI 编码平台建设，突出 Claude 在开发者工具生态中的案例影响。",
+      "category": "商业动态",
+      "importance": 2,
+      "tags": [
+        "Claude",
+        "Cursor",
+        "AI编程",
+        "创始人故事"
+      ],
+      "thread_group_id": "thread-claudeai-20260610-1712",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/claudeai/status/2064757539762295177",
+      "source": "Claude (Twitter)",
+      "title": "Claude发布问题解决者案例入口",
+      "summary": "Claude 补充给出「The Problem Solvers」系列入口，指向其展示创业者如何用 Claude 解决复杂问题的专题页面。该条是上一条 Cursor 案例线程的延伸，主要承担导流与案例合集索引作用。",
+      "category": "产品与功能",
+      "importance": 2,
+      "tags": [
+        "Claude",
+        "案例集",
+        "创业者",
+        "开发者生态"
+      ],
+      "practice_suggestions": [
+        "可将该专题作为企业 AI 应用案例库，筛选与自身行业相近的工作流，提炼可复用的 Claude 集成场景与评估指标。"
+      ],
+      "thread_group_id": "thread-claudeai-20260610-1712",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2064756984617021807",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude支持苹果Foundation Models",
+      "summary": "Claude Devs 宣布面向 Apple 开发者的新支持：可通过 Apple 的 Foundation Models 框架调用 Claude，用于多步推理、代码生成和更长上下文任务。这使 Swift/Apple 生态应用能在本地框架体验中接入 Claude 的远端能力。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "Claude",
+        "Apple",
+        "Foundation Models",
+        "Swift",
+        "开发者工具"
+      ],
+      "practice_suggestions": [
+        "Apple 开发团队可评估在现有 Foundation Models 调用路径中加入 Claude，用于需要长上下文或复杂推理的功能，并重点测试延迟、隐私边界与失败回退。"
+      ],
+      "thread_group_id": "thread-ClaudeDevs-20260610-1710",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2064756987112702303",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude接入SwiftUI结构化输出",
+      "summary": "Claude Devs 进一步说明，Apple Foundation Models 框架的类型化输出可直接进入 Claude 请求，开发者发送的是结构化数据而非原始用户文本。Claude 响应还能流式返回到同一个 SwiftUI 视图，降低 Apple 应用内集成多步 AI 交互的工程复杂度。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "Claude",
+        "SwiftUI",
+        "结构化输出",
+        "流式响应",
+        "Apple开发"
+      ],
+      "practice_suggestions": [
+        "可优先在 SwiftUI 原型中验证类型化输入到 Claude 的数据契约，并用流式响应改善生成式界面的等待体验，同时为敏感字段建立显式过滤层。"
+      ],
+      "thread_group_id": "thread-ClaudeDevs-20260610-1710",
+      "duplicate_of": null
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Run the repository `docs/prompts/daily-trigger.md` analysis-only workflow for Asia/Shanghai date `2026-06-12` to produce the daily analysis cache consumed by the reporter stage. 

### Description
- Added `data/analysis-cache/2026-06-12.json` containing 44 analyzed articles with synthesized Chinese `title`/`summary`, `category`, `importance`, `tags`, and carried-through `thread_group_id`/`duplicate_of` metadata. 
- Merged per-chunk outputs, applied aggressive event clustering and synthesis (examples: Grok Build plugin-marketplace cluster, Claude Managed Agents cluster, Anthropic Claude Corps, Fable workflow), and rewrote canonical entries to represent events with per-member `angle` annotations. 
- Computed a bullet-form `trend_paragraph` (3–5 bullets) restricted to daily-cadence sources and ensured all `practice_suggestions` values are arrays where present. 
- Cleaned up temporary `data/analysis-cache/{date}.chunk-*.json` scratch files after merge.

### Testing
- Validated JSON syntax with `python -m json.tool data/analysis-cache/2026-06-12.json` (success). 
- Ran custom Python schema checks that assert required article fields, deduped URLs, `practice_suggestions` array shape, and final article count (44) (success). 
- Confirmed chunk cleanup with the shell check for remaining `data/analysis-cache/2026-06-12.chunk-*.json` files (none remain). 
- Ran repository unit tests via `npm test` (`node --test scripts/*.test.js`) and all tests passed (15/15).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b6df186f483259dc67e4a763d0d49)