### PR TITLE
Add analysis and full daily report for 2026-06-14

### DIFF
--- a/data/analysis-cache/2026-06-14.json
+++ b/data/analysis-cache/2026-06-14.json
@@ -1,0 +1,208 @@
+{
+  "analyzed_at": "2026-06-15T10:08:18.161939+08:00",
+  "fetch_cache_ref": "data/fetch-cache/2026-06-14.json",
+  "trend_paragraph": "- **模型访问收紧**：Anthropic因美国指令暂停Claude Fable 5与Mythos 5访问，并切换相关回退路径。\n- **代理沙箱下沉**：Claude Managed Agents新增自托管沙箱指南，推动企业把代理执行环境纳入自控基础设施。\n- **开发文档代理化**：OpenAI开发者文档上线问答代理，可生成定制指南并衔接Codex工作流。\n- **编码工具落地**：Codex案例强调并行修改网站可压缩交付周期，显示代理式开发进入日常工程。",
+  "articles": [
+    {
+      "url": "https://x.com/karpathy/status/2065490793092337691",
+      "source": "Andrej Karpathy (Twitter)",
+      "title": "Karpathy盛赞SpaceX长期叙事",
+      "summary": "Karpathy称赞SpaceX从过去、现在到未来的整体故事令人震撼，并向团队表示祝贺。该帖主要是个人感想与致敬，没有提供新的AI技术、产品或研究信息。",
+      "category": "教程与观点",
+      "importance": 1,
+      "tags": [
+        "个人观点",
+        "SpaceX",
+        "产业叙事"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2065647770468487600",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude Build Day改用Opus 4.8",
+      "summary": "Claude Devs确认次日Build Day活动仍将照常举行，但底层模型改为Opus 4.8。结合其他同批公告，这更像是对模型可用性调整后的活动安排更新。",
+      "category": "产品与功能",
+      "importance": 3,
+      "tags": [
+        "Claude",
+        "Opus 4.8",
+        "开发者活动",
+        "模型切换"
+      ],
+      "practice_suggestions": [
+        "参加相关活动或复现实验时，确认示例和提示词默认运行在Opus 4.8上。",
+        "若已有基于其他Claude模型的演示，提前测试Opus 4.8的输出差异与成本表现。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": "https://x.com/AnthropicAI/status/2065597531644743999",
+      "angle": "活动模型调整"
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2065621176735646006",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude重置所有用户速率限制",
+      "summary": "Claude Devs表示已为所有用户重置5小时与每周速率限制。该更新属于服务运营层面的临时恢复措施，可能与同日模型访问变更或活动准备有关。",
+      "category": "产品与功能",
+      "importance": 2,
+      "tags": [
+        "Claude",
+        "速率限制",
+        "账户配额",
+        "服务恢复"
+      ],
+      "practice_suggestions": [
+        "如果此前被限流，可重新运行关键Claude工作流并记录新的可用额度。",
+        "对生产集成仍应保留限流重试和降级策略，避免依赖一次性配额重置。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2065597942602531163",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude Fable 5因政府指令暂停",
+      "summary": "Claude Devs称，因美国政府指令，Claude Fable 5将面向所有用户暂停访问并在产品中弃用。API客户会自动路由到Claude Sonnet 4.8，Claude Code也将使用Sonnet 4.8作为回退，而Opus 4.8、Sonnet 4.8和Haiku 4.8不受影响。",
+      "category": "政策与安全",
+      "importance": 5,
+      "tags": [
+        "Claude",
+        "出口管制",
+        "Fable 5",
+        "模型下线",
+        "Sonnet 4.8"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": "https://x.com/AnthropicAI/status/2065597531644743999",
+      "angle": "产品回退细节"
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2065494480837583297",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude托管代理新增自托管沙箱指南",
+      "summary": "Claude Managed Agents强调可运行在用户控制的沙箱中，支持自有基础设施或第三方提供商。官方文档新增Blaxel、E2B、Google Cloud、Namespace Labs和Modal等沙箱指南，并指向托管代理总览，方便团队按安全与部署约束选择执行环境。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "Claude Managed Agents",
+        "自托管沙箱",
+        "Claude Code",
+        "代理部署",
+        "开发者文档"
+      ],
+      "practice_suggestions": [
+        "评估自有基础设施与第三方沙箱的安全边界。",
+        "按文档为Claude Managed Agents配置隔离执行环境。",
+        "为代理任务建立网络、文件和凭据访问策略。"
+      ],
+      "thread_group_id": "thread-ClaudeDevs-20260612-1800",
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2065494482460836183",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude沙箱文档指向自托管方案",
+      "summary": "该帖补充指向Claude Managed Agents文档，强调可通过多个服务商了解自托管代码沙箱。它是同一线程中对新增沙箱指南的延伸，价值主要在于给开发者提供入口链接。",
+      "category": "产品与功能",
+      "importance": 3,
+      "tags": [
+        "Claude Code",
+        "文档",
+        "自托管沙箱",
+        "Managed Agents"
+      ],
+      "practice_suggestions": [
+        "阅读Managed Agents概览与具体提供商指南，确认所需权限、运行时和网络配置。",
+        "在引入生产前，用非敏感仓库测试代理在沙箱中的代码执行、依赖安装和超时控制。"
+      ],
+      "thread_group_id": "thread-ClaudeDevs-20260612-1800",
+      "duplicate_of": null,
+      "angle": "文档入口补充"
+    },
+    {
+      "url": "https://x.com/AnthropicAI/status/2065597531644743999",
+      "source": "Anthropic (Twitter)",
+      "title": "美国指令暂停Claude Fable与Mythos访问",
+      "summary": "美国政府以国家安全授权发布出口管制指令，要求暂停外国国民访问Claude Fable 5和Mythos 5，Anthropic表示已开始执行访问变更。Claude Devs补充说明，Fable 5相关流量将回退到Claude Sonnet 4.8，Claude Code也会使用Sonnet 4.8作为兜底。受此影响，Claude Build Day活动仍会举行，但改为基于Opus 4.8构建。",
+      "category": "政策与安全",
+      "importance": 5,
+      "tags": [
+        "出口管制",
+        "Claude Fable 5",
+        "Mythos 5",
+        "模型访问",
+        "Claude Code",
+        "Opus 4.8"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/OpenAIDevs/status/2065517012311593114",
+      "source": "OpenAI Devs (Twitter)",
+      "title": "Codex并行改站点缩短交付周期",
+      "summary": "OpenAI Devs分享案例称，Intelligence公司的开发者使用Codex并行更新网站多个部分，将原本一周的工作压缩到三天。该帖偏向产品案例，强调Codex在多任务代码修改中的效率收益。",
+      "category": "产品与功能",
+      "importance": 3,
+      "tags": [
+        "Codex",
+        "开发效率",
+        "并行任务",
+        "网站开发",
+        "案例"
+      ],
+      "practice_suggestions": [
+        "把网站改版任务拆成相互独立的小任务，让Codex并行处理并逐一审查差异。",
+        "为高频页面修改建立清晰验收清单，便于代理产出后快速验证视觉和功能。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/OpenAIDevs/status/2065507798268674366",
+      "source": "OpenAI Devs (Twitter)",
+      "title": "OpenAI文档代理可生成定制指南",
+      "summary": "OpenAI Devs表示新的开发者文档代理不只回答问题，还能根据用户描述的构建目标生成定制指南，包含提示词和相关资源。用户可在Codex中打开指南，或复制为Markdown用于队友、编辑器或其他工具。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "OpenAI",
+        "文档代理",
+        "Codex",
+        "定制指南",
+        "开发者体验"
+      ],
+      "practice_suggestions": [
+        "在启动新OpenAI集成前，先用文档代理生成项目专属指南，再转化为任务清单。",
+        "把生成的Markdown指南纳入仓库文档或Issue，方便团队复用同一提示词和资源链接。",
+        "对指南中的API参数和模型建议做人工复核，避免文档代理输出过时或不适用配置。"
+      ],
+      "thread_group_id": "thread-OpenAIDevs-20260612-1853",
+      "duplicate_of": null,
+      "angle": "定制指南生成"
+    },
+    {
+      "url": "https://x.com/OpenAIDevs/status/2065507724704858173",
+      "source": "OpenAI Devs (Twitter)",
+      "title": "OpenAI开发者文档上线问答代理",
+      "summary": "OpenAI开发者站点上线文档问答代理，可帮助开发者查询OpenAI产品问题并直达相关文档。该代理不只给出答案，还能根据用户描述的构建目标生成定制指南、提示词和相关资源，并支持在Codex中打开或复制为Markdown交给团队与编辑器使用。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "OpenAI文档",
+        "问答代理",
+        "Codex",
+        "开发者工具",
+        "提示词指南"
+      ],
+      "practice_suggestions": [
+        "用开发者文档代理为新项目生成初始实现指南。",
+        "将代理生成的Markdown交给Codex或团队成员复用。",
+        "验证代理给出的链接是否覆盖当前API版本。"
+      ],
+      "thread_group_id": "thread-OpenAIDevs-20260612-1853",
+      "duplicate_of": null
+    }
+  ]
+}

--- a/data/health.json
+++ b/data/health.json
@@ -1,139 +1,139 @@
 {
   "Berkeley RDI": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "The Batch": {
     "status": "alert",
     "last_success": "2026-05-08T06:38:45+08:00",
-    "consecutive_failures": 33,
+    "consecutive_failures": 34,
     "last_error": "HTTP 403 after 1 attempt"
   },
   "宝玉的分享": {
     "status": "alert",
     "last_success": "2026-06-06T06:44:07+08:00",
-    "consecutive_failures": 8,
-    "last_error": "newest item is 503.0h old, exceeds 336h threshold"
+    "consecutive_failures": 9,
+    "last_error": "newest item is 526.7h old, exceeds 336h threshold"
   },
   "OpenAI Blog": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Google AI Blog": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Anthropic Blog": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Anthropic Research": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Sam Altman (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Dario Amodei (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Demis Hassabis (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Andrej Karpathy (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Thariq (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Claude (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Claude Devs (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Anthropic (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "OpenAI (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "OpenAI Devs (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Meta AI (Twitter)": {
     "status": "degraded",
     "last_success": "2026-06-12T07:07:39+08:00",
-    "consecutive_failures": 1,
-    "last_error": "newest item is 175.5h old, exceeds 168h threshold"
+    "consecutive_failures": 2,
+    "last_error": "newest item is 199.1h old, exceeds 168h threshold"
   },
   "Google DeepMind (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Mistral AI (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "xAI (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "DeepSeek (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },
   "Qwen (Twitter)": {
     "status": "healthy",
-    "last_success": "2026-06-13T07:01:13+08:00",
+    "last_success": "2026-06-14T06:40:47+08:00",
     "consecutive_failures": 0,
     "last_error": null
   },

--- a/data/history.json
+++ b/data/history.json
@@ -18795,7 +18795,138 @@
           "个人观点"
         ]
       }
+    },
+    "33ca50c1917d8228c76b1b3337c284afaeeadef0a4e5a097214fa20c1ba6762c": {
+      "title": "美国指令暂停Claude Fable与Mythos访问",
+      "url": "https://x.com/AnthropicAI/status/2065597531644743999",
+      "source": "Anthropic (Twitter)",
+      "published_at": "2026-06-13T00:50:03.000000Z",
+      "fetched_at": "2026-06-15T10:08:18.161939+08:00",
+      "summary": "美国政府以国家安全授权发布出口管制指令，要求暂停外国国民访问Claude Fable 5和Mythos 5，Anthropic表示已开始执行访问变更。Claude Devs补充说明，Fable 5相关流量将回退到Claude Sonnet 4.8，Claude Code也会使用Sonnet 4.8作为兜底。受此影响，Claude Build Day活动仍会举行，但改为基于Opus 4.8构建。",
+      "category": "政策与安全",
+      "importance": 5,
+      "extras": {
+        "tags": [
+          "出口管制",
+          "Claude Fable 5",
+          "Mythos 5",
+          "模型访问",
+          "Claude Code",
+          "Opus 4.8"
+        ],
+        "cluster_members": [
+          {
+            "url": "https://x.com/ClaudeDevs/status/2065647770468487600",
+            "title": "Claude Build Day改用Opus 4.8",
+            "source": "Claude Devs (Twitter)",
+            "angle": "活动模型调整"
+          },
+          {
+            "url": "https://x.com/ClaudeDevs/status/2065597942602531163",
+            "title": "Claude Fable 5因政府指令暂停",
+            "source": "Claude Devs (Twitter)",
+            "angle": "产品回退细节"
+          }
+        ]
+      }
+    },
+    "3c6d53924996dacdfb123d9f52043d3b435e450769933a943f2a47884bc39c50": {
+      "title": "OpenAI文档代理可生成定制指南",
+      "url": "https://x.com/OpenAIDevs/status/2065507798268674366",
+      "source": "OpenAI Devs (Twitter)",
+      "published_at": "2026-06-12T18:53:29.000000Z",
+      "fetched_at": "2026-06-15T10:08:18.161939+08:00",
+      "summary": "OpenAI Devs表示新的开发者文档代理不只回答问题，还能根据用户描述的构建目标生成定制指南，包含提示词和相关资源。用户可在Codex中打开指南，或复制为Markdown用于队友、编辑器或其他工具。",
+      "category": "产品与功能",
+      "importance": 4,
+      "extras": {
+        "tags": [
+          "OpenAI",
+          "文档代理",
+          "Codex",
+          "定制指南",
+          "开发者体验"
+        ],
+        "practice_suggestions": [
+          "在启动新OpenAI集成前，先用文档代理生成项目专属指南，再转化为任务清单。",
+          "把生成的Markdown指南纳入仓库文档或Issue，方便团队复用同一提示词和资源链接。",
+          "对指南中的API参数和模型建议做人工复核，避免文档代理输出过时或不适用配置。"
+        ],
+        "thread_urls": [
+          "https://x.com/OpenAIDevs/status/2065507798268674366"
+        ]
+      }
+    },
+    "d5c509ef0c55dafc7e27ac88971a0837db5cd80f8d1b64d828a8349dcbaf8c93": {
+      "title": "Codex并行改站点缩短交付周期",
+      "url": "https://x.com/OpenAIDevs/status/2065517012311593114",
+      "source": "OpenAI Devs (Twitter)",
+      "published_at": "2026-06-12T19:30:05.000000Z",
+      "fetched_at": "2026-06-15T10:08:18.161939+08:00",
+      "summary": "OpenAI Devs分享案例称，Intelligence公司的开发者使用Codex并行更新网站多个部分，将原本一周的工作压缩到三天。该帖偏向产品案例，强调Codex在多任务代码修改中的效率收益。",
+      "category": "产品与功能",
+      "importance": 3,
+      "extras": {
+        "tags": [
+          "Codex",
+          "开发效率",
+          "并行任务",
+          "网站开发",
+          "案例"
+        ],
+        "practice_suggestions": [
+          "把网站改版任务拆成相互独立的小任务，让Codex并行处理并逐一审查差异。",
+          "为高频页面修改建立清晰验收清单，便于代理产出后快速验证视觉和功能。"
+        ]
+      }
+    },
+    "b4a1ebe737fc3512d54766a532f2855c9ad98c89a3692b6a97af90f0c73a815b": {
+      "title": "Claude沙箱文档指向自托管方案",
+      "url": "https://x.com/ClaudeDevs/status/2065494482460836183",
+      "source": "Claude Devs (Twitter)",
+      "published_at": "2026-06-12T18:00:34.000000Z",
+      "fetched_at": "2026-06-15T10:08:18.161939+08:00",
+      "summary": "该帖补充指向Claude Managed Agents文档，强调可通过多个服务商了解自托管代码沙箱。它是同一线程中对新增沙箱指南的延伸，价值主要在于给开发者提供入口链接。",
+      "category": "产品与功能",
+      "importance": 3,
+      "extras": {
+        "tags": [
+          "Claude Code",
+          "文档",
+          "自托管沙箱",
+          "Managed Agents"
+        ],
+        "practice_suggestions": [
+          "阅读Managed Agents概览与具体提供商指南，确认所需权限、运行时和网络配置。",
+          "在引入生产前，用非敏感仓库测试代理在沙箱中的代码执行、依赖安装和超时控制。"
+        ],
+        "thread_urls": [
+          "https://x.com/ClaudeDevs/status/2065494482460836183"
+        ]
+      }
+    },
+    "892f5dcbbc76f5b490a3f8d9fa36e5cc6dfdaa4ac3fd7c6ebc835a054317a48f": {
+      "title": "Claude重置所有用户速率限制",
+      "url": "https://x.com/ClaudeDevs/status/2065621176735646006",
+      "source": "Claude Devs (Twitter)",
+      "published_at": "2026-06-13T02:24:00.000000Z",
+      "fetched_at": "2026-06-15T10:08:18.161939+08:00",
+      "summary": "Claude Devs表示已为所有用户重置5小时与每周速率限制。该更新属于服务运营层面的临时恢复措施，可能与同日模型访问变更或活动准备有关。",
+      "category": "产品与功能",
+      "importance": 2,
+      "extras": {
+        "tags": [
+          "Claude",
+          "速率限制",
+          "账户配额",
+          "服务恢复"
+        ],
+        "practice_suggestions": [
+          "如果此前被限流，可重新运行关键Claude工作流并记录新的可用额度。",
+          "对生产集成仍应保留限流重试和降级策略，避免依赖一次性配额重置。"
+        ]
+      }
     }
   },
-  "last_fetch": "2026-06-13T10:16:30+08:00"
+  "last_fetch": "2026-06-15T10:08:18.161939+08:00"
 }

--- a/feed.xml
+++ b/feed.xml
@@ -27,46 +27,84 @@
       <guid isPermaLink="false">https://github.com/Zerokei/LLM-CatchUp/blob/main/reports/daily/2026-06-14.md</guid>
       <pubDate>Sun, 14 Jun 2026 00:00:00 GMT</pubDate>
       <category>daily</category>
-      <description><![CDATA[<h1>CatchUp 日报 — 2026-06-14（fallback，自动回退版）</h1>
+      <description><![CDATA[<h1>CatchUp 日报 — 2026-06-14</h1>
+<h2>今日趋势</h2>
+<ul>
+<li><strong>模型访问收紧</strong>：Anthropic因美国指令暂停Claude Fable 5与Mythos 5访问，并切换相关回退路径。</li>
+<li><strong>代理沙箱下沉</strong>：Claude Managed Agents新增自托管沙箱指南，推动企业把代理执行环境纳入自控基础设施。</li>
+<li><strong>开发文档代理化</strong>：OpenAI开发者文档上线问答代理，可生成定制指南并衔接Codex工作流。</li>
+<li><strong>编码工具落地</strong>：Codex案例强调并行修改网站可压缩交付周期，显示代理式开发进入日常工程。</li>
+</ul>
+<hr>
+<h2>文章详情</h2>
+<h3>1. <a href="https://x.com/AnthropicAI/status/2065597531644743999">美国指令暂停Claude Fable与Mythos访问</a></h3>
+<ul>
+<li><strong>来源</strong>: Anthropic (Twitter)</li>
+<li><strong>分类</strong>: 政策与安全</li>
+<li><strong>重要性</strong>: ⭐⭐⭐⭐⭐ (5/5)</li>
+<li><strong>标签</strong>: <code>出口管制</code> <code>Claude Fable 5</code> <code>Mythos 5</code> <code>模型访问</code> <code>Claude Code</code> <code>Opus 4.8</code></li>
+</ul>
+<p><strong>摘要</strong>: 美国政府以国家安全授权发布出口管制指令，要求暂停外国国民访问Claude Fable 5和Mythos 5，Anthropic表示已开始执行访问变更。Claude Devs补充说明，Fable 5相关流量将回退到Claude Sonnet 4.8，Claude Code也会使用Sonnet 4.8作为兜底。受此影响，Claude Build Day活动仍会举行，但改为基于Opus 4.8构建。</p>
+<p>📎 <strong>多角度报道</strong>:</p>
+<ul>
+<li><a href="https://x.com/ClaudeDevs/status/2065647770468487600">Claude Build Day改用Opus 4.8</a> · Claude Devs (Twitter) · 活动模型调整</li>
+<li><a href="https://x.com/ClaudeDevs/status/2065597942602531163">Claude Fable 5因政府指令暂停</a> · Claude Devs (Twitter) · 产品回退细节</li>
+</ul>
+<hr>
+<h3>2. <a href="https://x.com/OpenAIDevs/status/2065507798268674366">OpenAI文档代理可生成定制指南</a></h3>
+<ul>
+<li><strong>来源</strong>: OpenAI Devs (Twitter)</li>
+<li><strong>分类</strong>: 产品与功能</li>
+<li><strong>重要性</strong>: ⭐⭐⭐⭐ (4/5)</li>
+<li><strong>标签</strong>: <code>OpenAI</code> <code>文档代理</code> <code>Codex</code> <code>定制指南</code> <code>开发者体验</code></li>
+</ul>
+<p><strong>摘要</strong>: OpenAI Devs表示新的开发者文档代理不只回答问题，还能根据用户描述的构建目标生成定制指南，包含提示词和相关资源。用户可在Codex中打开指南，或复制为Markdown用于队友、编辑器或其他工具。</p>
 <blockquote>
-<p>Claude 分析环节未在预期窗口内产出；以下为仅标题+链接的兜底版本。</p>
+<p><strong>实践建议</strong></p>
+<ul>
+<li>在启动新OpenAI集成前，先用文档代理生成项目专属指南，再转化为任务清单。</li>
+<li>把生成的Markdown指南纳入仓库文档或Issue，方便团队复用同一提示词和资源链接。</li>
+<li>对指南中的API参数和模型建议做人工复核，避免文档代理输出过时或不适用配置。</li>
+</ul>
 </blockquote>
 <hr>
-<h2>Andrej Karpathy (Twitter)</h2>
+<h3>3. <a href="https://x.com/OpenAIDevs/status/2065517012311593114">Codex并行改站点缩短交付周期</a></h3>
 <ul>
-<li><a href="https://x.com/karpathy/status/2065490793092337691">In awe of SpaceX and its story - past, present and the future. You can think about it in 10+ different ways and continue re-blowing your mind in circles. Huge congrats to the team! 🚀</a></li>
+<li><strong>来源</strong>: OpenAI Devs (Twitter)</li>
+<li><strong>分类</strong>: 产品与功能</li>
+<li><strong>重要性</strong>: ⭐⭐⭐ (3/5)</li>
+<li><strong>标签</strong>: <code>Codex</code> <code>开发效率</code> <code>并行任务</code> <code>网站开发</code> <code>案例</code></li>
 </ul>
-<h2>Claude Devs (Twitter)</h2>
+<p><strong>摘要</strong>: OpenAI Devs分享案例称，Intelligence公司的开发者使用Codex并行更新网站多个部分，将原本一周的工作压缩到三天。该帖偏向产品案例，强调Codex在多任务代码修改中的效率收益。</p>
+<blockquote>
+<p><strong>实践建议</strong></p>
 <ul>
-<li><a href="https://x.com/ClaudeDevs/status/2065647770468487600">Tomorrow’s Build Day event is still on, we&#39;re building on Opus 4.8 instead. Thank you, we can’t wait to build with you tomorrow!</a></li>
-<li><a href="https://x.com/ClaudeDevs/status/2065621176735646006">We&#39;ve reset 5-hour and weekly rate limits for all users.</a></li>
-<li>[As a result of a US government directive, we are suspending access to Claude Fable 5 for all users. You can continue to use all other Claude models.</li>
+<li>把网站改版任务拆成相互独立的小任务，让Codex并行处理并逐一审查差异。</li>
+<li>为高频页面修改建立清晰验收清单，便于代理产出后快速验证视觉和功能。</li>
 </ul>
-<p>Here’s what this means for you:</p>
-<p>Across Claude pro](<a href="https://x.com/ClaudeDevs/status/2065597942602531163">https://x.com/ClaudeDevs/status/2065597942602531163</a>)</p>
+</blockquote>
+<hr>
+<h3>4. <a href="https://x.com/ClaudeDevs/status/2065494482460836183">Claude沙箱文档指向自托管方案</a></h3>
 <ul>
-<li>[Claude Managed Agents can operate in a sandbox you control, on your own infrastructure or with any provider you choose.</li>
+<li><strong>来源</strong>: Claude Devs (Twitter)</li>
+<li><strong>分类</strong>: 产品与功能</li>
+<li><strong>重要性</strong>: ⭐⭐⭐ (3/5)</li>
+<li><strong>标签</strong>: <code>Claude Code</code> <code>文档</code> <code>自托管沙箱</code> <code>Managed Agents</code></li>
 </ul>
-<p>Today we added new guides for @blaxelAI, @e2b, @googlecloud, @namespacelabs, an](<a href="https://x.com/ClaudeDevs/status/2065494480837583297">https://x.com/ClaudeDevs/status/2065494480837583297</a>)</p>
+<p><strong>摘要</strong>: 该帖补充指向Claude Managed Agents文档，强调可通过多个服务商了解自托管代码沙箱。它是同一线程中对新增沙箱指南的延伸，价值主要在于给开发者提供入口链接。</p>
+<blockquote>
+<p><strong>实践建议</strong></p>
 <ul>
-<li>[Learn more about self-hosted code sandboxes with these and other providers in the Claude Managed Agents docs:</li>
+<li>阅读Managed Agents概览与具体提供商指南，确认所需权限、运行时和网络配置。</li>
+<li>在引入生产前，用非敏感仓库测试代理在沙箱中的代码执行、依赖安装和超时控制。</li>
 </ul>
-<p><a href="https://t.co/uBoxh3eoyk">https://t.co/uBoxh3eoyk</a> <a href="https://t.co/tpUfWt2TFo%5D(https://x.com/ClaudeDevs/status/2065494482460836183)">https://t.co/tpUfWt2TFo](https://x.com/ClaudeDevs/status/2065494482460836183)</a></p>
-<h2>Anthropic (Twitter)</h2>
+</blockquote>
+<hr>
+<h2>速览</h2>
+<p>以下为重要度 ★★ 的简讯，仅列分类、标签与一句话摘要。</p>
 <ul>
-<li><a href="https://x.com/AnthropicAI/status/2065597531644743999">The US government, citing national security authorities, has issued an export control directive to suspend all access to Fable 5 and Mythos 5 by any foreign national, whether inside or outside the Uni</a></li>
+<li><strong>产品与功能</strong> | <code>Claude</code> <code>速率限制</code> <code>账户配额</code> <code>服务恢复</code> — Claude Devs表示已为所有用户重置5小时与每周速率限制。该更新属于服务运营层面的临时恢复措施，可能与同日模型访问变更或活动准备有关。 · <a href="https://x.com/ClaudeDevs/status/2065621176735646006">Claude Devs (Twitter)</a></li>
 </ul>
-<h2>OpenAI Devs (Twitter)</h2>
-<ul>
-<li><a href="https://x.com/OpenAIDevs/status/2065517012311593114">Codex is how @ndrewpignanelli at @intelligenceco updates multiple parts of a website in parallel, turning a week of work into three days. https://t.co/PHNWK5eamT</a></li>
-<li>[And it doesn’t stop at answers.</li>
-</ul>
-<p>Describe what you’re building and the agent will create a custom guide with a tailored prompt and relevant resources.</p>
-<p>Open the guide in Codex or copy it as Markdown f](<a href="https://x.com/OpenAIDevs/status/2065507798268674366">https://x.com/OpenAIDevs/status/2065507798268674366</a>)</p>
-<ul>
-<li>[Ask our developer docs. They’ll show you the way</li>
-</ul>
-<p>The new docs agent on 🔗<a href="https://t.co/G1783HdxH4">https://t.co/G1783HdxH4</a> helps you find answers about OpenAI products and takes you directly to the relevant documentation. htt](<a href="https://x.com/OpenAIDevs/status/2065507724704858173">https://x.com/OpenAIDevs/status/2065507724704858173</a>)</p>
 ]]></description>
     </item>
     <item>
@@ -3728,23 +3766,23 @@
 <blockquote>
 <p><strong>实践建议</strong></p>
 <ul>
-<li>试用升级后的 AI 搜索框，体验多模态输入与建议式提问</li>
-<li>评估 Search 信息智能体的后台监控能力在信息追踪类需求中的应用</li>
+<li><strong>来源</strong>: OpenAI Blog</li>
+<li><strong>分类</strong>: 政策与安全</li>
+<li><strong>标签</strong>: <code>内容溯源</code> <code>C2PA</code> <code>SynthID</code> <code>AI 水印</code> <code>AI 透明度</code></li>
 </ul>
-</blockquote>
-<hr>
-<h3>13. <a href="https://blog.google/products-and-platforms/products/google-one/google-ai-subscriptions/">Google 订阅调整：新增 100 美元 AI Ultra 套餐，顶级套餐降至 200 美元</a></h3>
-<ul>
-<li><strong>来源</strong>: Google AI Blog</li>
-<li><strong>分类</strong>: 产品与功能</li>
-<li><strong>重要性</strong>: ⭐⭐⭐ (3/5)</li>
-<li><strong>标签</strong>: <code>Google</code> <code>AI订阅</code> <code>AI Ultra</code> <code>定价</code> <code>Gemini</code></li>
-</ul>
-<p><strong>摘要</strong>: Google I/O 2026 公布 AI 订阅更新：推出面向开发者与技术人员的 100 美元/月 AI Ultra 套餐，含 Gemini 应用与 Antigravity 5 倍用量、20TB 存储与 YouTube Premium；同时将顶级 AI Ultra 套餐从 250 美元降至 200 美元。所有套餐获 Gemini Omni 与 Gemini 3.5 Flash 访问权，并引入「按算力计费」的用量模型，每 5 小时刷新一次额度。</p>
-<blockquote>
-<p><strong>实践建议</strong></p>
-<ul>
-<li>对比 100 美元与 200 美元 AI Ultra 套餐的用量额度与功能差异，按团队开发强度选择合适层级</li>
+<p><strong>摘要</strong>: OpenAI 推出多层级内容溯源方案以提升 AI 生成内容的可识别性。它已成为 C2PA 合规生成产品，使内容凭证可被其他平台读取并跨平台传递；同时与 Google 合作，为 ChatGPT、Codex 和 API 生成的图像加入 DeepMind 的不可见 SynthID 水印，弥补元数据易被剥离的缺陷——水印在截图等变换后仍能保留，与元数据互补。OpenAI 还预览了一款面向公众的验证工具，可检测上传图像是否由 OpenAI 工具生成，初期仅支持 OpenAI 内容，未来计划扩展至跨平台。</p>
+<li><a href="https://x.com/OpenAI/status/2056793648571011232">OpenAI 强化内容溯源：C2PA 认证 + SynthID 水印 + 公开验证工具</a> · OpenAI (Twitter) · 官方推特要点速览</li>
+<li><strong>商业动态</strong> | <code>OpenAI</code> <code>ChatGPT</code> <code>图像生成</code> <code>Images 2.0</code> <code>播客</code> — OpenAI 透露 ChatGPT 每周图像生成量已超过 15 亿张。在最新一期 OpenAI 播客中，研究员 kenjihata 与产品负责人 adele__li 探讨了自 Images 2.0 发布以来涌现的新用例与使用趋势。 OpenAI 提供了其官方播客在 Spotify、Apple Podcasts 和 YouTube 三个平台的收听链接。该推文为上一条 Images 2.0 播客介绍的补充自回复。 · <a href="https://x.com/OpenAI/status/2056849157860831239">OpenAI (Twitter)</a></li>
+<li><strong>教程与观点</strong> | <code>Cognition</code> <code>Devin</code> <code>Claude</code> <code>AI软件工程师</code> <code>Scott Wu</code> — Anthropic 在「The Problem Solvers」系列中介绍 Cognition 创始人 Scott Wu，其团队打造了基于 Claude 的 AI 软件工程师 Devin。Scott Wu 希望让每个工程团队的软件构建速度提升 10 倍。 Anthropic 宣布推出全新系列「The Problem Solvers」，专题报道那些借助 Claude 解决棘手问题的创始人。相关内容已发布于 claude.com/problem-solvers。 · <a href="https://x.com/claudeai/status/2056805728774402428">Claude (Twitter)</a></li>
+<li><strong>商业动态</strong> | <code>Google</code> <code>Gemini</code> <code>黑客松</code> <code>XPRIZE</code> <code>开发者活动</code> — Google DeepMind 宣布举办「Build with Gemini」XPRIZE 黑客松，奖金池高达 200 万美元。开发者受邀使用 Gemini 工具构建解决全球重大挑战的实际应用，涵盖减少食物浪费、辅助科学研究等方向。 · <a href="https://x.com/GoogleDeepMind/status/2056794085680468294">Google DeepMind (Twitter)</a></li>
+<li><strong>产品与功能</strong> | <code>Antigravity</code> <code>Google DeepMind</code> <code>开发者工具</code> <code>AI 编程</code> — Google DeepMind 宣布扩展其 Antigravity 开发者生态系统，目标是帮助开发者把精力从繁琐的调试中解放出来，转而专注于架构与设计等真正重要的工作。该推文为相关公告线程的开端。 Google DeepMind 宣布为 Antigravity 推出三种全新交互方式：Antigravity 2.0 提供多智能体可同时协作于同一项目的「任务控制台」；CLI 提供终端界面用于与智能体协作；SDK 工具包让软件可自动接入并调用 Google 的 AI 智能体。 · <a href="https://x.com/GoogleDeepMind/status/2056790405937856791">Google DeepMind (Twitter)</a></li>
+<li><strong>商业动态</strong> | <code>Andrej Karpathy</code> <code>Anthropic</code> <code>人事变动</code> <code>LLM 研发</code> — 知名 AI 研究者 Andrej Karpathy 发布个人动态，宣布已加入 Anthropic。他认为未来几年将是 LLM 前沿发展的关键塑形期，对加入团队、重回前沿研发工作感到非常兴奋，同时表示仍对教育充满热情并计划在适当时机继续相关工作。Anthropic 官方账号 Claude Devs 及公司员工随即发文表示欢迎。 · <a href="https://x.com/karpathy/status/2056753169888334312">Andrej Karpathy (Twitter)</a></li>
+<li><strong>产品与功能</strong> | <code>usage credits</code> <code>用量积分</code> <code>命名调整</code> <code>Claude</code> <code>计费</code> — Claude 已在全平台将「extra usage」更名为「usage credits」。用户的支出限额、自动充值设置以及已购买的积分均原样保留，不受改名影响。 Claude 说明将「extra usage」更名为「usage credits」的原因：该机制最初仅指触及套餐上限后的付费，但如今用量积分的作用已扩展，可直接驱动如快速模式等功能。 · <a href="https://x.com/ClaudeDevs/status/2056543965672083966">Claude Devs (Twitter)</a></li>
+<li><strong>商业动态</strong> | <code>KPMG</code> <code>Anthropic</code> <code>企业部署</code> <code>Claude</code> <code>私募股权</code> — 审计与咨询巨头 KPMG 宣布与 Anthropic 达成全球战略联盟，将 Claude 嵌入其客户工作平台 Digital Gateway，并向全球 27.6 万名员工全员开放。双方将共建面向私募股权组合公司的 Claude 产品，KPMG 成为 Anthropic 在 PE 领域的首选合作伙伴，并把 Claude Code、Cowork 与 Managed Agents 用于税务、法律与网络安全等场景。 · <a href="https://www.anthropic.com/news/anthropic-kpmg">Anthropic Blog</a></li>
+<li><strong>产品与功能</strong> | <code>OpenAI</code> <code>Codex</code> <code>远程连接</code> <code>文档</code> — OpenAI Devs 在推文串中给出 Codex 远程连接功能的官方文档链接（developers.openai.com/codex/remote-connections），配合此前介绍的在 Mac 上保持 Codex 运行、从手机端继续工作的能力。 · <a href="https://x.com/OpenAIDevs/status/2056442469114687858">OpenAI Devs (Twitter)</a></li>
+<li><strong>产品与功能</strong> | <code>Claude</code> <code>提示缓存</code> <code>Console</code> <code>诊断</code> — Anthropic 在推文串中给出 Claude 提示缓存诊断功能的入口与文档链接：可在 Claude Console（platform.claude.com/usage/cache）查看，并通过 cache-diagnostics 文档了解更多用法。 · <a href="https://x.com/ClaudeDevs/status/2056434423982444801">Claude Devs (Twitter)</a></li>
+<li><strong>商业动态</strong> | <code>Anthropic</code> <code>收购</code> <code>Stainless</code> <code>SDK</code> <code>MCP</code> — Anthropic 宣布收购 Stainless——一家专注 SDK 与 MCP 服务器工具的公司，自 API 早期起便驱动每一代官方 Anthropic SDK 的生成。Stainless 能把 API 规范转换为 TypeScript、Python、Go、Java 等多语言的原生级 SDK、CLI 与 MCP 服务器，此次收购旨在增强 Claude 平台连接数据与工具的能力、推进 Agent 连接性。 · <a href="https://x.com/AnthropicAI/status/2056419620643541012">Anthropic (Twitter)</a></li>
+<li><strong>教程与观点</strong> | <code>提示词</code> <code>Claude</code> <code>规格实现</code> <code>实现笔记</code> <code>工作流</code> — Thariq 在 Claude 协助下重写了一条走红的提示词模板，要求 Agent 在实现规格的过程中持续维护一个 implementation-notes.html 文件。该笔记需记录设计决策（规格模糊时的取舍）、有意偏离规格之处及原因、考虑过的替代方案与权衡，以及希望人类确认或修订的开放问题。 · <a href="https://x.com/trq212/status/2056418157305454805">Thariq (Twitter)</a></li>
 <li>了解新的「按算力计费」用量模型，规划复杂编码/视频提示的额度消耗</li>
 </ul>
 </blockquote>

--- a/reports/daily/2026-06-14.html
+++ b/reports/daily/2026-06-14.html
@@ -311,54 +311,94 @@ footer.colophon a:hover { color: var(--accent); }
           <hr class="primary-rule" />
         </header>
 
-        <div class="prose"><blockquote>
-<p>Claude 分析环节未在预期窗口内产出；以下为仅标题+链接的兜底版本。</p>
+        <div class="prose"><h2 id="h-1">今日趋势</h2>
+<ul>
+<li><strong>模型访问收紧</strong>：Anthropic因美国指令暂停Claude Fable 5与Mythos 5访问，并切换相关回退路径。</li>
+<li><strong>代理沙箱下沉</strong>：Claude Managed Agents新增自托管沙箱指南，推动企业把代理执行环境纳入自控基础设施。</li>
+<li><strong>开发文档代理化</strong>：OpenAI开发者文档上线问答代理，可生成定制指南并衔接Codex工作流。</li>
+<li><strong>编码工具落地</strong>：Codex案例强调并行修改网站可压缩交付周期，显示代理式开发进入日常工程。</li>
+</ul>
+<hr>
+<h2 id="h-2">文章详情</h2>
+<h3 id="h-3">1. <a href="https://x.com/AnthropicAI/status/2065597531644743999">美国指令暂停Claude Fable与Mythos访问</a></h3>
+<ul>
+<li><strong>来源</strong>: Anthropic (Twitter)</li>
+<li><strong>分类</strong>: 政策与安全</li>
+<li><strong>重要性</strong>: ⭐⭐⭐⭐⭐ (5/5)</li>
+<li><strong>标签</strong>: <code>出口管制</code> <code>Claude Fable 5</code> <code>Mythos 5</code> <code>模型访问</code> <code>Claude Code</code> <code>Opus 4.8</code></li>
+</ul>
+<p><strong>摘要</strong>: 美国政府以国家安全授权发布出口管制指令，要求暂停外国国民访问Claude Fable 5和Mythos 5，Anthropic表示已开始执行访问变更。Claude Devs补充说明，Fable 5相关流量将回退到Claude Sonnet 4.8，Claude Code也会使用Sonnet 4.8作为兜底。受此影响，Claude Build Day活动仍会举行，但改为基于Opus 4.8构建。</p>
+<p>📎 <strong>多角度报道</strong>:</p>
+<ul>
+<li><a href="https://x.com/ClaudeDevs/status/2065647770468487600">Claude Build Day改用Opus 4.8</a> · Claude Devs (Twitter) · 活动模型调整</li>
+<li><a href="https://x.com/ClaudeDevs/status/2065597942602531163">Claude Fable 5因政府指令暂停</a> · Claude Devs (Twitter) · 产品回退细节</li>
+</ul>
+<hr>
+<h3 id="h-4">2. <a href="https://x.com/OpenAIDevs/status/2065507798268674366">OpenAI文档代理可生成定制指南</a></h3>
+<ul>
+<li><strong>来源</strong>: OpenAI Devs (Twitter)</li>
+<li><strong>分类</strong>: 产品与功能</li>
+<li><strong>重要性</strong>: ⭐⭐⭐⭐ (4/5)</li>
+<li><strong>标签</strong>: <code>OpenAI</code> <code>文档代理</code> <code>Codex</code> <code>定制指南</code> <code>开发者体验</code></li>
+</ul>
+<p><strong>摘要</strong>: OpenAI Devs表示新的开发者文档代理不只回答问题，还能根据用户描述的构建目标生成定制指南，包含提示词和相关资源。用户可在Codex中打开指南，或复制为Markdown用于队友、编辑器或其他工具。</p>
+<blockquote>
+<p><strong>实践建议</strong></p>
+<ul>
+<li>在启动新OpenAI集成前，先用文档代理生成项目专属指南，再转化为任务清单。</li>
+<li>把生成的Markdown指南纳入仓库文档或Issue，方便团队复用同一提示词和资源链接。</li>
+<li>对指南中的API参数和模型建议做人工复核，避免文档代理输出过时或不适用配置。</li>
+</ul>
 </blockquote>
 <hr>
-<h2 id="h-1">Andrej Karpathy (Twitter)</h2>
+<h3 id="h-5">3. <a href="https://x.com/OpenAIDevs/status/2065517012311593114">Codex并行改站点缩短交付周期</a></h3>
 <ul>
-<li><a href="https://x.com/karpathy/status/2065490793092337691">In awe of SpaceX and its story - past, present and the future. You can think about it in 10+ different ways and continue re-blowing your mind in circles. Huge congrats to the team! 🚀</a></li>
+<li><strong>来源</strong>: OpenAI Devs (Twitter)</li>
+<li><strong>分类</strong>: 产品与功能</li>
+<li><strong>重要性</strong>: ⭐⭐⭐ (3/5)</li>
+<li><strong>标签</strong>: <code>Codex</code> <code>开发效率</code> <code>并行任务</code> <code>网站开发</code> <code>案例</code></li>
 </ul>
-<h2 id="h-2">Claude Devs (Twitter)</h2>
+<p><strong>摘要</strong>: OpenAI Devs分享案例称，Intelligence公司的开发者使用Codex并行更新网站多个部分，将原本一周的工作压缩到三天。该帖偏向产品案例，强调Codex在多任务代码修改中的效率收益。</p>
+<blockquote>
+<p><strong>实践建议</strong></p>
 <ul>
-<li><a href="https://x.com/ClaudeDevs/status/2065647770468487600">Tomorrow’s Build Day event is still on, we&#39;re building on Opus 4.8 instead. Thank you, we can’t wait to build with you tomorrow!</a></li>
-<li><a href="https://x.com/ClaudeDevs/status/2065621176735646006">We&#39;ve reset 5-hour and weekly rate limits for all users.</a></li>
-<li>[As a result of a US government directive, we are suspending access to Claude Fable 5 for all users. You can continue to use all other Claude models.</li>
+<li>把网站改版任务拆成相互独立的小任务，让Codex并行处理并逐一审查差异。</li>
+<li>为高频页面修改建立清晰验收清单，便于代理产出后快速验证视觉和功能。</li>
 </ul>
-<p>Here’s what this means for you:</p>
-<p>Across Claude pro](<a href="https://x.com/ClaudeDevs/status/2065597942602531163">https://x.com/ClaudeDevs/status/2065597942602531163</a>)</p>
+</blockquote>
+<hr>
+<h3 id="h-6">4. <a href="https://x.com/ClaudeDevs/status/2065494482460836183">Claude沙箱文档指向自托管方案</a></h3>
 <ul>
-<li>[Claude Managed Agents can operate in a sandbox you control, on your own infrastructure or with any provider you choose.</li>
+<li><strong>来源</strong>: Claude Devs (Twitter)</li>
+<li><strong>分类</strong>: 产品与功能</li>
+<li><strong>重要性</strong>: ⭐⭐⭐ (3/5)</li>
+<li><strong>标签</strong>: <code>Claude Code</code> <code>文档</code> <code>自托管沙箱</code> <code>Managed Agents</code></li>
 </ul>
-<p>Today we added new guides for @blaxelAI, @e2b, @googlecloud, @namespacelabs, an](<a href="https://x.com/ClaudeDevs/status/2065494480837583297">https://x.com/ClaudeDevs/status/2065494480837583297</a>)</p>
+<p><strong>摘要</strong>: 该帖补充指向Claude Managed Agents文档，强调可通过多个服务商了解自托管代码沙箱。它是同一线程中对新增沙箱指南的延伸，价值主要在于给开发者提供入口链接。</p>
+<blockquote>
+<p><strong>实践建议</strong></p>
 <ul>
-<li>[Learn more about self-hosted code sandboxes with these and other providers in the Claude Managed Agents docs:</li>
+<li>阅读Managed Agents概览与具体提供商指南，确认所需权限、运行时和网络配置。</li>
+<li>在引入生产前，用非敏感仓库测试代理在沙箱中的代码执行、依赖安装和超时控制。</li>
 </ul>
-<p><a href="https://t.co/uBoxh3eoyk">https://t.co/uBoxh3eoyk</a> <a href="https://t.co/tpUfWt2TFo%5D(https://x.com/ClaudeDevs/status/2065494482460836183)">https://t.co/tpUfWt2TFo](https://x.com/ClaudeDevs/status/2065494482460836183)</a></p>
-<h2 id="h-3">Anthropic (Twitter)</h2>
+</blockquote>
+<hr>
+<h2 id="h-7">速览</h2>
+<p>以下为重要度 ★★ 的简讯，仅列分类、标签与一句话摘要。</p>
 <ul>
-<li><a href="https://x.com/AnthropicAI/status/2065597531644743999">The US government, citing national security authorities, has issued an export control directive to suspend all access to Fable 5 and Mythos 5 by any foreign national, whether inside or outside the Uni</a></li>
+<li><strong>产品与功能</strong> | <code>Claude</code> <code>速率限制</code> <code>账户配额</code> <code>服务恢复</code> — Claude Devs表示已为所有用户重置5小时与每周速率限制。该更新属于服务运营层面的临时恢复措施，可能与同日模型访问变更或活动准备有关。 · <a href="https://x.com/ClaudeDevs/status/2065621176735646006">Claude Devs (Twitter)</a></li>
 </ul>
-<h2 id="h-4">OpenAI Devs (Twitter)</h2>
-<ul>
-<li><a href="https://x.com/OpenAIDevs/status/2065517012311593114">Codex is how @ndrewpignanelli at @intelligenceco updates multiple parts of a website in parallel, turning a week of work into three days. https://t.co/PHNWK5eamT</a></li>
-<li>[And it doesn’t stop at answers.</li>
-</ul>
-<p>Describe what you’re building and the agent will create a custom guide with a tailored prompt and relevant resources.</p>
-<p>Open the guide in Codex or copy it as Markdown f](<a href="https://x.com/OpenAIDevs/status/2065507798268674366">https://x.com/OpenAIDevs/status/2065507798268674366</a>)</p>
-<ul>
-<li>[Ask our developer docs. They’ll show you the way</li>
-</ul>
-<p>The new docs agent on 🔗<a href="https://t.co/G1783HdxH4">https://t.co/G1783HdxH4</a> helps you find answers about OpenAI products and takes you directly to the relevant documentation. htt](<a href="https://x.com/OpenAIDevs/status/2065507724704858173">https://x.com/OpenAIDevs/status/2065507724704858173</a>)</p>
 </div>
       </article>
   <aside class="toc" aria-label="On this page">
     <div class="toc-label">本期目录</div>
     <ul>
-      <li class="toc-h2"><a href="#h-1">Andrej Karpathy (Twitter)</a></li>
-      <li class="toc-h2"><a href="#h-2">Claude Devs (Twitter)</a></li>
-      <li class="toc-h2"><a href="#h-3">Anthropic (Twitter)</a></li>
-      <li class="toc-h2"><a href="#h-4">OpenAI Devs (Twitter)</a></li>
+      <li class="toc-h2"><a href="#h-1">今日趋势</a></li>
+      <li class="toc-h3"><a href="#h-3">1. 美国指令暂停Claude Fable与Mythos访问</a></li>
+      <li class="toc-h3"><a href="#h-4">2. OpenAI文档代理可生成定制指南</a></li>
+      <li class="toc-h3"><a href="#h-5">3. Codex并行改站点缩短交付周期</a></li>
+      <li class="toc-h3"><a href="#h-6">4. Claude沙箱文档指向自托管方案</a></li>
+      <li class="toc-h2"><a href="#h-7">速览</a></li>
     </ul>
   </aside>
     </div>

--- a/reports/daily/2026-06-14.md
+++ b/reports/daily/2026-06-14.md
@@ -1,42 +1,80 @@
-# CatchUp 日报 — 2026-06-14（fallback，自动回退版）
+# CatchUp 日报 — 2026-06-14
 
-> Claude 分析环节未在预期窗口内产出；以下为仅标题+链接的兜底版本。
+## 今日趋势
+
+- **模型访问收紧**：Anthropic因美国指令暂停Claude Fable 5与Mythos 5访问，并切换相关回退路径。
+- **代理沙箱下沉**：Claude Managed Agents新增自托管沙箱指南，推动企业把代理执行环境纳入自控基础设施。
+- **开发文档代理化**：OpenAI开发者文档上线问答代理，可生成定制指南并衔接Codex工作流。
+- **编码工具落地**：Codex案例强调并行修改网站可压缩交付周期，显示代理式开发进入日常工程。
 
 ---
 
-## Andrej Karpathy (Twitter)
+## 文章详情
 
-- [In awe of SpaceX and its story - past, present and the future. You can think about it in 10+ different ways and continue re-blowing your mind in circles. Huge congrats to the team! 🚀](https://x.com/karpathy/status/2065490793092337691)
+### 1. [美国指令暂停Claude Fable与Mythos访问](https://x.com/AnthropicAI/status/2065597531644743999)
 
-## Claude Devs (Twitter)
+- **来源**: Anthropic (Twitter)
+- **分类**: 政策与安全
+- **重要性**: ⭐⭐⭐⭐⭐ (5/5)
+- **标签**: `出口管制` `Claude Fable 5` `Mythos 5` `模型访问` `Claude Code` `Opus 4.8`
 
-- [Tomorrow’s Build Day event is still on, we're building on Opus 4.8 instead. Thank you, we can’t wait to build with you tomorrow!](https://x.com/ClaudeDevs/status/2065647770468487600)
-- [We've reset 5-hour and weekly rate limits for all users.](https://x.com/ClaudeDevs/status/2065621176735646006)
-- [As a result of a US government directive, we are suspending access to Claude Fable 5 for all users. You can continue to use all other Claude models.
+**摘要**: 美国政府以国家安全授权发布出口管制指令，要求暂停外国国民访问Claude Fable 5和Mythos 5，Anthropic表示已开始执行访问变更。Claude Devs补充说明，Fable 5相关流量将回退到Claude Sonnet 4.8，Claude Code也会使用Sonnet 4.8作为兜底。受此影响，Claude Build Day活动仍会举行，但改为基于Opus 4.8构建。
 
-Here’s what this means for you:
+📎 **多角度报道**:
+- [Claude Build Day改用Opus 4.8](https://x.com/ClaudeDevs/status/2065647770468487600) · Claude Devs (Twitter) · 活动模型调整
+- [Claude Fable 5因政府指令暂停](https://x.com/ClaudeDevs/status/2065597942602531163) · Claude Devs (Twitter) · 产品回退细节
 
-Across Claude pro](https://x.com/ClaudeDevs/status/2065597942602531163)
-- [Claude Managed Agents can operate in a sandbox you control, on your own infrastructure or with any provider you choose.
+---
 
-Today we added new guides for @blaxelAI, @e2b, @googlecloud, @namespacelabs, an](https://x.com/ClaudeDevs/status/2065494480837583297)
-- [Learn more about self-hosted code sandboxes with these and other providers in the Claude Managed Agents docs:
+### 2. [OpenAI文档代理可生成定制指南](https://x.com/OpenAIDevs/status/2065507798268674366)
 
-https://t.co/uBoxh3eoyk https://t.co/tpUfWt2TFo](https://x.com/ClaudeDevs/status/2065494482460836183)
+- **来源**: OpenAI Devs (Twitter)
+- **分类**: 产品与功能
+- **重要性**: ⭐⭐⭐⭐ (4/5)
+- **标签**: `OpenAI` `文档代理` `Codex` `定制指南` `开发者体验`
 
-## Anthropic (Twitter)
+**摘要**: OpenAI Devs表示新的开发者文档代理不只回答问题，还能根据用户描述的构建目标生成定制指南，包含提示词和相关资源。用户可在Codex中打开指南，或复制为Markdown用于队友、编辑器或其他工具。
 
-- [The US government, citing national security authorities, has issued an export control directive to suspend all access to Fable 5 and Mythos 5 by any foreign national, whether inside or outside the Uni](https://x.com/AnthropicAI/status/2065597531644743999)
+> **实践建议**
+> - 在启动新OpenAI集成前，先用文档代理生成项目专属指南，再转化为任务清单。
+> - 把生成的Markdown指南纳入仓库文档或Issue，方便团队复用同一提示词和资源链接。
+> - 对指南中的API参数和模型建议做人工复核，避免文档代理输出过时或不适用配置。
 
-## OpenAI Devs (Twitter)
+---
 
-- [Codex is how @ndrewpignanelli at @intelligenceco updates multiple parts of a website in parallel, turning a week of work into three days. https://t.co/PHNWK5eamT](https://x.com/OpenAIDevs/status/2065517012311593114)
-- [And it doesn’t stop at answers.
+### 3. [Codex并行改站点缩短交付周期](https://x.com/OpenAIDevs/status/2065517012311593114)
 
-Describe what you’re building and the agent will create a custom guide with a tailored prompt and relevant resources.
+- **来源**: OpenAI Devs (Twitter)
+- **分类**: 产品与功能
+- **重要性**: ⭐⭐⭐ (3/5)
+- **标签**: `Codex` `开发效率` `并行任务` `网站开发` `案例`
 
-Open the guide in Codex or copy it as Markdown f](https://x.com/OpenAIDevs/status/2065507798268674366)
-- [Ask our developer docs. They’ll show you the way
+**摘要**: OpenAI Devs分享案例称，Intelligence公司的开发者使用Codex并行更新网站多个部分，将原本一周的工作压缩到三天。该帖偏向产品案例，强调Codex在多任务代码修改中的效率收益。
 
-The new docs agent on 🔗https://t.co/G1783HdxH4 helps you find answers about OpenAI products and takes you directly to the relevant documentation. htt](https://x.com/OpenAIDevs/status/2065507724704858173)
+> **实践建议**
+> - 把网站改版任务拆成相互独立的小任务，让Codex并行处理并逐一审查差异。
+> - 为高频页面修改建立清晰验收清单，便于代理产出后快速验证视觉和功能。
+
+---
+
+### 4. [Claude沙箱文档指向自托管方案](https://x.com/ClaudeDevs/status/2065494482460836183)
+
+- **来源**: Claude Devs (Twitter)
+- **分类**: 产品与功能
+- **重要性**: ⭐⭐⭐ (3/5)
+- **标签**: `Claude Code` `文档` `自托管沙箱` `Managed Agents`
+
+**摘要**: 该帖补充指向Claude Managed Agents文档，强调可通过多个服务商了解自托管代码沙箱。它是同一线程中对新增沙箱指南的延伸，价值主要在于给开发者提供入口链接。
+
+> **实践建议**
+> - 阅读Managed Agents概览与具体提供商指南，确认所需权限、运行时和网络配置。
+> - 在引入生产前，用非敏感仓库测试代理在沙箱中的代码执行、依赖安装和超时控制。
+
+---
+
+## 速览
+
+以下为重要度 ★★ 的简讯，仅列分类、标签与一句话摘要。
+
+- **产品与功能** | `Claude` `速率限制` `账户配额` `服务恢复` — Claude Devs表示已为所有用户重置5小时与每周速率限制。该更新属于服务运营层面的临时恢复措施，可能与同日模型访问变更或活动准备有关。 · [Claude Devs (Twitter)](https://x.com/ClaudeDevs/status/2065621176735646006)
 

--- a/reports/daily/2026-06-14.ops.md
+++ b/reports/daily/2026-06-14.ops.md
@@ -1,0 +1,46 @@
+# CatchUp 日报 · 运维数据 — 2026-06-14
+
+## 今日概览
+
+共抓取 **10** 篇文章（合并多推文线程后为 5 条独立条目），来自 **4** 个数据源（过滤后在报告中展示 **5** 篇）。
+
+| 分类 | 数量 |
+|------|------|
+| 模型发布 | 0 |
+| 研究 | 0 |
+| 产品与功能 | 4 |
+| 商业动态 | 0 |
+| 政策与安全 | 1 |
+| 教程与观点 | 0 |
+
+---
+
+## 数据源状态
+
+| 数据源 | 状态 |
+|--------|------|
+| Berkeley RDI | ✅ 正常（窗口内 0 文） |
+| The Batch | ❌ 错误（HTTP 403 after 1 attempt） |
+| 宝玉的分享 | ⚠️ 过期（newest item is 526.7h old, exceeds 336h threshold） |
+| OpenAI Blog | ✅ 正常（窗口内 0 文） |
+| Google AI Blog | ✅ 正常（窗口内 0 文） |
+| Anthropic Blog | ✅ 正常（窗口内 0 文） |
+| Anthropic Research | ✅ 正常（窗口内 0 文） |
+| Sam Altman (Twitter) | ✅ 正常（窗口内 0 文） |
+| Dario Amodei (Twitter) | ✅ 正常（窗口内 0 文） |
+| Demis Hassabis (Twitter) | ✅ 正常（窗口内 0 文） |
+| Andrej Karpathy (Twitter) | ✅ 正常（窗口内 1 文） |
+| Thariq (Twitter) | ✅ 正常（窗口内 0 文） |
+| Claude (Twitter) | ✅ 正常（窗口内 0 文） |
+| Claude Devs (Twitter) | ✅ 正常（窗口内 5 文） |
+| Anthropic (Twitter) | ✅ 正常（窗口内 1 文） |
+| OpenAI (Twitter) | ✅ 正常（窗口内 0 文） |
+| OpenAI Devs (Twitter) | ✅ 正常（窗口内 3 文） |
+| Meta AI (Twitter) | ⚠️ 过期（newest item is 199.1h old, exceeds 168h threshold） |
+| Google DeepMind (Twitter) | ✅ 正常（窗口内 0 文） |
+| Mistral AI (Twitter) | ✅ 正常（窗口内 0 文） |
+| xAI (Twitter) | ✅ 正常（窗口内 0 文） |
+| DeepSeek (Twitter) | ✅ 正常（窗口内 0 文） |
+| Qwen (Twitter) | ✅ 正常（窗口内 0 文） |
+
+注：共过滤 0 篇低重要度条目（importance < 2）——这些条目仍记入 history.json。


### PR DESCRIPTION
### Motivation

- Populate the analyzer output for the 2026-06-14 fetch snapshot so the reporter can render a full editorial (replacing the fallback-only output). 
- Cluster related items (Claude/Anthropic model-access notices, Claude Managed Agents thread, OpenAI docs agent thread) and synthesize a trend paragraph for the daily digest.

### Description

- Added the merged analysis cache `data/analysis-cache/2026-06-14.json` produced from a subagent chunk and removed the transient chunk file after merge. 
- Produced the editorial `reports/daily/2026-06-14.md` and ops sidecar `reports/daily/2026-06-14.ops.md`, and regenerated the HTML page `reports/daily/2026-06-14.html` and `feed.xml`. 
- Updated persisted state files `data/history.json` and `data/health.json` to include the new articles, clusters, `cluster_members`/`angle` annotations, and refreshed source health stamps. 
- The analysis implements thread merging, duplicate clustering, per-article Chinese titles/summaries/categories/importance/tags, and a `trend_paragraph` of 3–5 bullets per the trigger prompt.

### Testing

- Ran the report builder with `REPORT_DATE=2026-06-14 node scripts/build-report.js` which completed and produced the expected report artifacts. 
- Ran the unit tests with `npm test` (all 15 tests passed). 
- Validated `data/analysis-cache/2026-06-14.json` with `node -e "JSON.parse(require('fs').readFileSync('data/analysis-cache/2026-06-14.json','utf8'))"` which succeeded. 
- Verified presence of `reports/daily/2026-06-14.ops.md` and that the transient chunk file `data/analysis-cache/2026-06-14.chunk-0.json` was cleaned up; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f5d98f5508325886d13794c829e27)