### PR TITLE
chore(catchup): add daily analysis cache for 2026-06-16

### DIFF
--- a/data/analysis-cache/2026-06-16.json
+++ b/data/analysis-cache/2026-06-16.json
@@ -1,0 +1,87 @@
+{
+  "analyzed_at": "2026-06-16T16:31:53+08:00",
+  "fetch_cache_ref": "data/fetch-cache/2026-06-16.json",
+  "trend_paragraph": "- **开发工具嵌入**：OpenAI Codex 插件与 Grok 接入 Warp 都在把模型能力前移到编码现场。\n- **代码模型提速**：Kimi K2.7 Code HighSpeed 强调吞吐提升，适合先用真实仓库做延迟与质量评测。\n- **算力基建加码**：Google 在阿拉巴马追加15亿美元数据中心投资，继续扩张AI基础设施底座。",
+  "articles": [
+    {
+      "url": "https://blog.google/innovation-and-ai/infrastructure-and-cloud/global-network/alabama-investment-june-2026/",
+      "source": "Google AI Blog",
+      "title": "谷歌加码阿拉巴马数据中心",
+      "summary": "谷歌宣布在2026至2027年投入15亿美元，扩建其位于阿拉巴马州杰克逊县的数据中心园区，并称将自行承担全部电力与基础设施成本。公司还设立200万美元能源影响基金，并捐赠55万美元STEM学习套件，以强化当地能源效率、教育和就业承诺。",
+      "category": "商业动态",
+      "importance": 2,
+      "tags": [
+        "谷歌",
+        "数据中心",
+        "基础设施",
+        "能源",
+        "社区投资"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/OpenAIDevs/status/2066634415955136728",
+      "source": "OpenAI Devs (Twitter)",
+      "title": "Codex新增OpenAI开发者插件",
+      "summary": "OpenAI Devs介绍了Codex中的OpenAI Developers插件，主打帮助开发者设置API密钥、查找合适文档并在构建过程中辅助调试。这属于围绕OpenAI工具链的开发者体验增强，目标是减少从配置到排错的摩擦。",
+      "category": "产品与功能",
+      "importance": 3,
+      "tags": [
+        "OpenAI",
+        "Codex",
+        "开发者工具",
+        "插件",
+        "API"
+      ],
+      "practice_suggestions": [
+        "在Codex项目中试用该插件，检查API密钥配置和文档检索是否能减少上下文切换。",
+        "将常见OpenAI API调试步骤整理成团队模板，配合插件用于新人上手。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/xai/status/2066625790704521699",
+      "source": "xAI (Twitter)",
+      "title": "Grok订阅接入Warp开发环境",
+      "summary": "xAI宣布SuperGrok或X Premium订阅用户现在可以在Warp中使用相关能力。用户可在Warp Agent设置中切换到Grok Build模型，显示xAI正在把模型能力嵌入开发者终端与Agent工作流。",
+      "category": "产品与功能",
+      "importance": 3,
+      "tags": [
+        "xAI",
+        "Grok",
+        "Warp",
+        "开发环境",
+        "Agent"
+      ],
+      "practice_suggestions": [
+        "若团队已使用Warp，可用小型代码修改任务评估Grok Build的响应质量、延迟和成本替代价值。",
+        "对比现有编码助手在终端内的权限边界与审计能力，再决定是否引入到生产代码库。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    },
+    {
+      "url": "https://x.com/Kimi_Moonshot/status/2066467110960959833",
+      "source": "Kimi (Twitter)",
+      "title": "Kimi K2.7代码模型推出高速模式",
+      "summary": "Moonshot介绍Kimi K2.7 Code HighSpeed，这是其开源多模态代码模型的高速模式，面向编码任务宣称最高可达6倍提速。该能力正在向Kimi Code Beta、Kimi API开发者和Kimi Business用户逐步开放，但受算力容量限制仍为有限访问。",
+      "category": "模型发布",
+      "importance": 4,
+      "tags": [
+        "Kimi",
+        "代码模型",
+        "高速模式",
+        "多模态",
+        "API"
+      ],
+      "practice_suggestions": [
+        "申请或检查Kimi Code Beta/API访问权限，用团队真实代码补全与重构任务测试吞吐和质量。",
+        "针对短上下文和中等长度输入分别做基准，验证高速模式是否适合CI辅助审查或批量代码迁移。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Run the repository's daily analysis trigger (`docs/prompts/daily-trigger.md`) for Asia/Shanghai date `2026-06-16` to produce the analyzer output consumed by the reporter stage. 
- Persist a validated analysis cache so downstream report generation can proceed without manual intervention.

### Description
- Add `data/analysis-cache/2026-06-16.json` containing `analyzed_at`, `fetch_cache_ref`, a three-bullet `trend_paragraph`, and four analyzed daily articles (Google Alabama data-center investment, Codex OpenAI Developers plugin, Grok integration in Warp, and Kimi K2.7 Code HighSpeed). 
- Create and validate a subagent chunk file `data/analysis-cache/2026-06-16.chunk-0.json`, merge its contents into the final cache, and remove the scratch chunk file. 
- Validate each article has required fields (`url`, `source`, `title`, `summary`, `category`, `importance`, `tags`) before writing the final `data/analysis-cache/{date}.json`.

### Testing
- Ran `node` JSON parse and schema validation on `data/analysis-cache/2026-06-16.json`, which succeeded. 
- Ran the chunk parsing and article-field validation script that confirmed 4 valid articles and wrote the merged cache, which succeeded. 
- Attempted to push to the remote but the checkout has no remote configured so the remote push step did not complete; the analysis cache file was created and validated locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31091875fc8325b8ee8294b72cab8e)