### PR TITLE
chore(catchup): add daily analysis cache for 2026-06-17

### DIFF
--- a/data/analysis-cache/2026-06-17.json
+++ b/data/analysis-cache/2026-06-17.json
@@ -1,0 +1,438 @@
+{
+  "analyzed_at": "2026-06-17T14:04:19+08:00",
+  "fetch_cache_ref": "data/fetch-cache/2026-06-17.json",
+  "trend_paragraph": "- **评测转向真实部署**：OpenAI 的部署仿真与前沿评测讨论都在补足传统基准失真问题。\n- **编程智能体进入生产**：Claude Code 研究与 Claude Managed Agents 显示落地重点转向岗位差异、沙箱和观测。\n- **开源与具身模型升温**：GLM-5.2 开源权重和 Qwen-Robot Suite 分别推进通用模型与机器人基础模型。\n- **开发者工具继续扩区**：Codex 插件、欧洲开放与 Grok 接入 Warp 都在争夺日常开发入口。",
+  "articles": [
+    {
+      "url": "https://x.com/trq212/status/2067021344341098670",
+      "source": "Thariq (Twitter)",
+      "title": "Slack 开始渲染 HTML 附件预览",
+      "summary": "Thariq 观察到 Slack 已开始渲染 HTML 附件预览，这会改变团队在聊天中查看网页或文档附件的方式。该变化偏向小型产品体验更新，可能影响内部分享、调试链接和安全审查流程。",
+      "category": "产品与功能",
+      "importance": 2,
+      "tags": [
+        "Slack",
+        "HTML预览",
+        "附件渲染",
+        "协作工具"
+      ],
+      "practice_suggestions": [
+        "检查内部分享的 HTML 附件是否会暴露敏感预览内容。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://x.com/OpenAI/status/2066969640727969845",
+      "source": "OpenAI (Twitter)",
+      "title": "部署模拟降低模型评测感知",
+      "summary": "OpenAI 称，模拟部署能把模型的评测感知降低到接近真实生产流量的水平。该方法也被扩展到带有状态工具的智能体部署场景，显示只要工具模拟器具备足够上下文和能力，就能产生较真实的轨迹。",
+      "category": "研究",
+      "importance": 4,
+      "tags": [
+        "OpenAI",
+        "部署模拟",
+        "评测感知",
+        "智能体安全"
+      ],
+      "thread_group_id": "thread-OpenAI-20260616-1942",
+      "duplicate_of": "https://openai.com/index/deployment-simulation",
+      "cadence": "daily",
+      "angle": "评测感知下降"
+    },
+    {
+      "url": "https://x.com/OpenAI/status/2066969642774720961",
+      "source": "OpenAI (Twitter)",
+      "title": "公开数据也可辅助验证部署评测",
+      "summary": "OpenAI 指出，部署模拟最好使用有代表性的生产数据，但外部评测者往往无法访问这类数据。其配套 Alignment 博客研究了公开 WildChat 数据集，认为它虽然精度较低，仍能为部署行为提供有用信号。",
+      "category": "研究",
+      "importance": 3,
+      "tags": [
+        "OpenAI",
+        "WildChat",
+        "公开评测",
+        "部署行为"
+      ],
+      "thread_group_id": "thread-OpenAI-20260616-1942",
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://x.com/OpenAI/status/2066969635099144682",
+      "source": "OpenAI (Twitter)",
+      "title": "OpenAI 用真实请求预演模型部署风险",
+      "summary": "OpenAI 介绍「Deployment Simulation」：用去标识化的近期用户请求重放候选模型响应，以在发布前预测真实使用中的不良行为。该方法在 GPT-5 系列 Thinking 部署中改善了风险频率估计、提前暴露新的失配行为，并可扩展到带工具的智能体场景。",
+      "category": "研究",
+      "importance": 4,
+      "tags": [
+        "OpenAI",
+        "Deployment Simulation",
+        "模型安全",
+        "GPT-5",
+        "智能体"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": "https://openai.com/index/deployment-simulation",
+      "cadence": "daily",
+      "angle": "研究发布"
+    },
+    {
+      "url": "https://x.com/AnthropicAI/status/2066969542010806561",
+      "source": "Anthropic (Twitter)",
+      "title": "Anthropic 将跟踪 Claude Code 工作变化",
+      "summary": "Anthropic 表示，将把 Claude Code 使用研究中的若干指标纳入 Anthropic Economic Index，用于持续观察工作性质的变化。报告基于隐私保护分析，关注谁在使用 Claude Code、做什么任务以及成功率如何变化。",
+      "category": "研究",
+      "importance": 4,
+      "tags": [
+        "Anthropic",
+        "Claude Code",
+        "经济指数",
+        "工作变化"
+      ],
+      "thread_group_id": "thread-AnthropicAI-20260616-1941",
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://x.com/AnthropicAI/status/2066969540412780644",
+      "source": "Anthropic (Twitter)",
+      "title": "领域熟练度提升 Claude Code 成功率",
+      "summary": "Anthropic 发现，按提问方式和专业词汇判断出的领域专家更容易在 Claude Code 会话中成功。不过中级用户与专家的差距并不大，说明对具体领域足够熟练就可能有效地用 AI 完成编码任务。",
+      "category": "研究",
+      "importance": 3,
+      "tags": [
+        "Claude Code",
+        "领域专家",
+        "成功率",
+        "AI编程"
+      ],
+      "thread_group_id": "thread-AnthropicAI-20260616-1941",
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://x.com/AnthropicAI/status/2066969536423985295",
+      "source": "Anthropic (Twitter)",
+      "title": "Claude Code 任务价值七个月增 27%",
+      "summary": "Anthropic 将 Claude Code 会话中的工作类型与自由职业市场上的相似任务成本进行比较，发现 2025 年 10 月到 2026 年 4 月平均会话价值增长 27%。这显示用户正把更复杂、更高价值的工作交给编码智能体处理。",
+      "category": "研究",
+      "importance": 3,
+      "tags": [
+        "Claude Code",
+        "任务价值",
+        "AI编程",
+        "劳动市场"
+      ],
+      "thread_group_id": "thread-AnthropicAI-20260616-1941",
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://x.com/AnthropicAI/status/2066969538193920307",
+      "source": "Anthropic (Twitter)",
+      "title": "非软件职业用 Claude Code 也接近工程师",
+      "summary": "Anthropic 比较了不同职业的 Claude Code 成功率，在最严格的成功定义下，各领域与软件工程之间的差距都在 7 个百分点以内。结果暗示编码智能体的有效使用不只依赖传统编程职业背景。",
+      "category": "研究",
+      "importance": 3,
+      "tags": [
+        "Claude Code",
+        "职业分布",
+        "成功衡量",
+        "AI普及"
+      ],
+      "thread_group_id": "thread-AnthropicAI-20260616-1941",
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://x.com/AnthropicAI/status/2066969532380721386",
+      "source": "Anthropic (Twitter)",
+      "title": "Anthropic 发布 Claude Code 使用框架",
+      "summary": "Anthropic 的经济研究提出了描述交互式 AI 编程助手使用的新框架，分析工作模式、用户职业、任务价值和成功条件。约 40 万个会话显示，人类主要决定做什么，Claude Code 更多决定如何实现，领域理解会显著影响成效。",
+      "category": "研究",
+      "importance": 4,
+      "tags": [
+        "Anthropic",
+        "Claude Code",
+        "经济研究",
+        "智能体编程"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": "https://www.anthropic.com/research/claude-code-expertise",
+      "cadence": "daily",
+      "angle": "框架介绍"
+    },
+    {
+      "url": "https://x.com/Zai_org/status/2066938937344495629",
+      "source": "Z.ai (Twitter)",
+      "title": "智谱开源 GLM-5.2 权重",
+      "summary": "智谱宣布开源 GLM-5.2 权重，延续 GLM 系列面向通用推理与开发者落地的开放路线。作为新一代开源权重模型，它值得关注其许可证、上下文能力、工具调用与代码基准表现。开发者可优先验证本地部署成本与中文任务质量。",
+      "category": "模型发布",
+      "importance": 5,
+      "tags": [
+        "GLM-5.2",
+        "开源权重",
+        "智谱",
+        "模型发布"
+      ],
+      "practice_suggestions": [
+        "下载权重并用内部中文任务集做基线评测。",
+        "检查许可证、上下文长度和推理成本是否适合生产试点。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://x.com/OpenAI/status/2066934697004089626",
+      "source": "OpenAI (Twitter)",
+      "title": "OpenAI播客讨论前沿评测",
+      "summary": "OpenAI补充发布播客收听渠道，延续同一线程中关于模型评测的讨论。该内容本身主要是分发入口，但指向的主题是如何在基准饱和或被规避时继续衡量前沿模型进展。",
+      "category": "教程与观点",
+      "importance": 1,
+      "tags": [
+        "OpenAI",
+        "播客",
+        "模型评测",
+        "基准测试"
+      ],
+      "thread_group_id": "thread-OpenAI-20260616-1723",
+      "duplicate_of": "https://x.com/OpenAI/status/2066934692641956231",
+      "cadence": "daily",
+      "angle": "播客入口"
+    },
+    {
+      "url": "https://x.com/OpenAI/status/2066934692641956231",
+      "source": "OpenAI (Twitter)",
+      "title": "OpenAI 播客聚焦前沿模型评测",
+      "summary": "OpenAI 通过播客讨论在基准饱和或被刷榜后，如何继续衡量和预测模型进展。内容聚焦前沿评测团队的实践，强调用更贴近真实能力边界的方法补足传统 benchmark。收听链接作为同一线程的分发补充。",
+      "category": "教程与观点",
+      "importance": 3,
+      "tags": [
+        "前沿评测",
+        "基准饱和",
+        "模型进展",
+        "OpenAI播客"
+      ],
+      "thread_group_id": "thread-OpenAI-20260616-1723",
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2066926620989169932",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude托管智能体分享落地经验",
+      "summary": "Claude Devs表示，新博客整理了团队选择Claude Managed Agents的常见原因、若干案例研究和上手建议。重点围绕把智能体投入生产时的托管、凭证、沙箱与可观测性等工程问题。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "Claude",
+        "托管智能体",
+        "生产部署",
+        "案例研究"
+      ],
+      "practice_suggestions": [
+        "评估现有智能体项目中凭证管理、沙箱隔离和日志追踪是否适合迁移到托管方案。",
+        "用一个低风险内部流程试点Claude Managed Agents，验证权限边界和可观测性是否满足上线要求。"
+      ],
+      "thread_group_id": "thread-ClaudeDevs-20260616-1651",
+      "duplicate_of": "https://x.com/ClaudeDevs/status/2066926619714007115",
+      "cadence": "daily",
+      "angle": "案例与上手"
+    },
+    {
+      "url": "https://x.com/ClaudeDevs/status/2066926619714007115",
+      "source": "Claude Devs (Twitter)",
+      "title": "Claude Managed Agents 分享生产落地经验",
+      "summary": "Claude Devs 介绍 Applied AI 团队关于 Claude Managed Agents 的实践文章，聚焦企业把智能体推向生产时遇到的凭证、沙箱、可观测性等问题。后续线程补充了采用该方案的常见动机、案例与上手建议。整体更像生产部署指南，而不是单一功能发布。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "Claude",
+        "托管智能体",
+        "生产部署",
+        "沙箱",
+        "可观测性"
+      ],
+      "practice_suggestions": [
+        "评估现有 Agent 是否缺少凭证隔离、沙箱和观测链路。",
+        "用案例清单梳理适合迁移到托管智能体的工作流。"
+      ],
+      "thread_group_id": "thread-ClaudeDevs-20260616-1651",
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://x.com/OpenAIDevs/status/2066916479438930166",
+      "source": "OpenAI Devs (Twitter)",
+      "title": "Codex 更多功能向欧洲开放",
+      "summary": "OpenAI Devs 宣布 Codex 的更多功能面向欧洲用户开放，降低区域可用性限制。该更新主要影响已经在欧洲使用 OpenAI 开发者工具的团队，可进一步测试代码生成与代理式开发流程。",
+      "category": "产品与功能",
+      "importance": 3,
+      "tags": [
+        "Codex",
+        "欧洲开放",
+        "开发者工具",
+        "OpenAI"
+      ],
+      "practice_suggestions": [
+        "让欧洲团队复测 Codex 功能可用性与权限配置。",
+        "更新内部开发者工具文档中的区域限制说明。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://x.com/Alibaba_Qwen/status/2066870215070322786",
+      "source": "Qwen (Twitter)",
+      "title": "Qwen-Robot Suite连接语言与行动",
+      "summary": "Qwen称Qwen-Robot Suite旨在让AI从聊天机器人走向现实世界的物理行动。该帖补充指向官方博客和演示，属于同一机器人基础模型套件发布线程的一部分。",
+      "category": "模型发布",
+      "importance": 4,
+      "tags": [
+        "Qwen",
+        "机器人",
+        "具身智能",
+        "物理行动"
+      ],
+      "practice_suggestions": [
+        "关注官方演示中导航、操作和世界模型分别适合的机器人任务，筛选可复现实验场景。",
+        "将自然语言动作接口作为原型入口，测试现有机器人任务是否能统一到同一指令层。"
+      ],
+      "thread_group_id": "thread-Alibaba_Qwen-20260616-1307",
+      "duplicate_of": "https://x.com/Alibaba_Qwen/status/2066870197122899980",
+      "cadence": "daily",
+      "angle": "演示入口"
+    },
+    {
+      "url": "https://x.com/Alibaba_Qwen/status/2066870210716647591",
+      "source": "Qwen (Twitter)",
+      "title": "Qwen-RobotWorld统一具身世界建模",
+      "summary": "Qwen介绍Qwen-RobotWorld以自然语言作为通用动作接口，把末端执行器姿态、驾驶命令和导航航点统一表示。模型覆盖20多种具身形态和500多类动作，并在860万视频文本对、超过2亿帧的Embodied World Knowledge语料上共同训练。",
+      "category": "模型发布",
+      "importance": 4,
+      "tags": [
+        "Qwen-RobotWorld",
+        "世界模型",
+        "具身智能",
+        "视频文本训练",
+        "机器人"
+      ],
+      "practice_suggestions": [
+        "优先阅读Qwen-RobotWorld报告，确认其动作表示能否映射到自有机器人控制栈。",
+        "用EWMBench、DreamGen等公开基准结果作为选型参考，避免只依据演示判断可用性。"
+      ],
+      "thread_group_id": "thread-Alibaba_Qwen-20260616-1307",
+      "duplicate_of": "https://x.com/Alibaba_Qwen/status/2066870197122899980",
+      "cadence": "daily",
+      "angle": "世界建模"
+    },
+    {
+      "url": "https://x.com/Alibaba_Qwen/status/2066870197122899980",
+      "source": "Qwen (Twitter)",
+      "title": "Qwen 发布三模型机器人套件",
+      "summary": "Qwen 推出 Qwen-Robot Suite，包含 Qwen-RobotNav、Qwen-RobotManip 与 Qwen-RobotWorld，试图把语言理解延伸到真实世界行动。RobotWorld 将自然语言作为通用动作接口，连接通用视频生成与具身模型。官方还提供演示与博客，展示从聊天机器人走向物理行动的路线。",
+      "category": "模型发布",
+      "importance": 4,
+      "tags": [
+        "Qwen-Robot",
+        "具身智能",
+        "机器人模型",
+        "动作接口",
+        "世界建模"
+      ],
+      "practice_suggestions": [
+        "查看官方 demo，挑选导航或操作任务做小规模复现。",
+        "评估自然语言动作接口能否接入现有机器人仿真环境。",
+        "跟踪 RobotWorld 对视频生成模型和具身控制的衔接方式。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://openai.com/index/deployment-simulation",
+      "source": "OpenAI Blog",
+      "title": "OpenAI 用部署仿真预判模型风险",
+      "summary": "OpenAI 提出用近期匿名真实请求模拟候选模型上线后的行为，以在发布前发现传统基准难以覆盖的风险。相关结果显示，部署仿真能降低模型对评测场景的感知，并可扩展到带状态工具的智能体部署。配套讨论还强调，外部公开数据可补充验证，但最有价值的是具代表性的生产流量。",
+      "category": "研究",
+      "importance": 4,
+      "tags": [
+        "部署仿真",
+        "模型评测",
+        "安全评估",
+        "智能体",
+        "生产流量"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://www.anthropic.com/research/claude-code-expertise",
+      "source": "Anthropic Research",
+      "title": "Claude Code 数据揭示专业知识仍关键",
+      "summary": "Anthropic 发布经济研究框架，用 Claude Code 使用数据追踪 AI 编程工具如何改变工作任务与价值结构。研究显示，Claude Code 任务的估算月价值七个月增长 27%，非软件职业的成功率也接近工程师。与此同时，具备领域熟练度的用户仍更容易完成目标，相关指标将纳入 Anthropic Economic Index。",
+      "category": "研究",
+      "importance": 4,
+      "tags": [
+        "Claude Code",
+        "经济指数",
+        "专业知识",
+        "任务价值",
+        "工作变化"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null,
+      "cadence": "daily",
+      "practice_suggestions": [
+        "将 Claude Code 使用数据按岗位和任务类型分层统计。",
+        "为高价值任务沉淀领域词表与验收证据，提高完成率。"
+      ]
+    },
+    {
+      "url": "https://x.com/OpenAIDevs/status/2066634415955136728",
+      "source": "OpenAI Devs (Twitter)",
+      "title": "OpenAI 推出 Codex 开发者插件",
+      "summary": "OpenAI Devs 推出 Codex 开发者插件，指向更模块化的开发者工作流扩展方式。插件机制有望让团队把仓库约定、工具调用和开发流程封装进 Codex 使用体验。适合先在低风险仓库验证安装、权限和任务边界。",
+      "category": "产品与功能",
+      "importance": 4,
+      "tags": [
+        "Codex",
+        "开发者插件",
+        "工作流扩展",
+        "OpenAI"
+      ],
+      "practice_suggestions": [
+        "选一个内部工具链场景试做 Codex 插件原型。",
+        "审查插件权限边界，避免默认暴露敏感仓库操作。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null,
+      "cadence": "daily"
+    },
+    {
+      "url": "https://x.com/xai/status/2066625790704521699",
+      "source": "xAI (Twitter)",
+      "title": "Grok 订阅接入 Warp 终端",
+      "summary": "xAI 宣布 Grok 订阅与 Warp 终端集成，让开发者可在命令行环境中使用 Grok 能力。该合作提升了 Grok 在开发者日常工作流中的触达，但本质是渠道与产品集成，而非底层模型能力更新。",
+      "category": "产品与功能",
+      "importance": 3,
+      "tags": [
+        "Grok",
+        "Warp",
+        "终端工具",
+        "开发者体验"
+      ],
+      "practice_suggestions": [
+        "在非生产项目中测试 Grok + Warp 的命令行辅助体验。",
+        "比较其与现有终端 AI 助手在隐私和上下文处理上的差异。"
+      ],
+      "thread_group_id": null,
+      "duplicate_of": null,
+      "cadence": "daily"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Run the source-of-truth daily-trigger workflow for Asia/Shanghai date `2026-06-17` to produce the analysis-only artifact consumed by the reporter stage.

### Description
- Add `data/analysis-cache/2026-06-17.json` containing `analyzed_at`, `fetch_cache_ref`, a 3-5 bullet `trend_paragraph`, and 22 analyzed article objects with fields required by the renderer. 
- Perform cluster synthesis and annotation (canonical selection, `duplicate_of` assignments, and `angle` fields) for multi-source events such as OpenAI deployment-simulation, Claude Code / Managed Agents, and Qwen robot suite. 
- Remove temporary chunk scratch files after merge and leave the consolidated analysis cache as the single produced artifact.

### Testing
- Validated the produced JSON with `node -e "JSON.parse(require('fs').readFileSync('data/analysis-cache/2026-06-17.json','utf8'))"`, which succeeded. 
- The analysis cache was prepared in the repository and is present as `data/analysis-cache/2026-06-17.json`, but publishing to the remote failed because this environment has no `origin` remote configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32373f3a6c8325a5692fc8cd3224f7)